### PR TITLE
[Feature] 결제 엔티티 구현

### DIFF
--- a/src/main/java/com/idukbaduk/itseats/payment/entity/Payment.java
+++ b/src/main/java/com/idukbaduk/itseats/payment/entity/Payment.java
@@ -1,0 +1,64 @@
+package com.idukbaduk.itseats.payment.entity;
+
+import com.idukbaduk.itseats.global.BaseEntity;
+import com.idukbaduk.itseats.payment.entity.enums.DeliveryType;
+import com.idukbaduk.itseats.payment.entity.enums.PaymentMethod;
+import com.idukbaduk.itseats.payment.entity.enums.PaymentStatus;
+import com.idukbaduk.itseats.payment.entity.enums.RiderRequestOption;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(name = "payment")
+public class Payment extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "payment_id")
+    private Long paymentId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "delivery_type", nullable = false)
+    private DeliveryType deliveryType;
+
+    @Column(name = "discount_value", nullable = false)
+    private int discountValue;
+
+    @Column(name = "total_cost", nullable = false)
+    private int totalCost;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "payment_method", nullable = false)
+    private PaymentMethod paymentMethod;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "payment_status", nullable = false)
+    private PaymentStatus paymentStatus;
+
+    @Column(name = "store_request")
+    private String storeRequest;
+
+    @Column(name = "store_request_option", nullable = false)
+    private boolean storeRequestOption;
+
+    @Column(name = "rider_request")
+    private String riderRequest;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "rider_request_option")
+    private RiderRequestOption riderRequestOption;
+}

--- a/src/main/java/com/idukbaduk/itseats/payment/entity/enums/DeliveryType.java
+++ b/src/main/java/com/idukbaduk/itseats/payment/entity/enums/DeliveryType.java
@@ -1,0 +1,8 @@
+package com.idukbaduk.itseats.payment.entity.enums;
+
+public enum DeliveryType {
+
+    DEFAULT,
+    ONLY,
+    ONE
+}

--- a/src/main/java/com/idukbaduk/itseats/payment/entity/enums/DeliveryType.java
+++ b/src/main/java/com/idukbaduk/itseats/payment/entity/enums/DeliveryType.java
@@ -3,6 +3,5 @@ package com.idukbaduk.itseats.payment.entity.enums;
 public enum DeliveryType {
 
     DEFAULT,
-    ONLY,
-    ONE
+    ONLY_ONE
 }

--- a/src/main/java/com/idukbaduk/itseats/payment/entity/enums/PaymentMethod.java
+++ b/src/main/java/com/idukbaduk/itseats/payment/entity/enums/PaymentMethod.java
@@ -1,0 +1,8 @@
+package com.idukbaduk.itseats.payment.entity.enums;
+
+public enum PaymentMethod {
+
+    CARD,
+    KAKAO,
+    MEET
+}

--- a/src/main/java/com/idukbaduk/itseats/payment/entity/enums/PaymentStatus.java
+++ b/src/main/java/com/idukbaduk/itseats/payment/entity/enums/PaymentStatus.java
@@ -3,6 +3,6 @@ package com.idukbaduk.itseats.payment.entity.enums;
 public enum PaymentStatus {
 
     COMPLETED,
-    CANCELLED,
+    CANCELED,
     FAILED
 }

--- a/src/main/java/com/idukbaduk/itseats/payment/entity/enums/PaymentStatus.java
+++ b/src/main/java/com/idukbaduk/itseats/payment/entity/enums/PaymentStatus.java
@@ -1,0 +1,8 @@
+package com.idukbaduk.itseats.payment.entity.enums;
+
+public enum PaymentStatus {
+
+    COMPLETED,
+    CANCELLED,
+    FAILED
+}

--- a/src/main/java/com/idukbaduk/itseats/payment/entity/enums/RiderRequestOption.java
+++ b/src/main/java/com/idukbaduk/itseats/payment/entity/enums/RiderRequestOption.java
@@ -1,0 +1,12 @@
+package com.idukbaduk.itseats.payment.entity.enums;
+
+public enum RiderRequestOption {
+
+    NONE,
+    SELF_RECEIVE,
+    DROP_AT_DOOR_BELL_OK,
+    DROP_AT_DOOR_BELL_NO,
+    CALL_ON_ARRIVAL,
+    MESSAGE_ON_ARRIVAL,
+    CUSTOM_INPUT
+}


### PR DESCRIPTION
## #️⃣연관된 이슈
 
#5
 
 ## 📝작업 내용
 
### Payment
- 결제 Entity

### 결제 관련 Enum
#### DeliveryType
- 배달 방식

타입 | 설명
--|--
DEFAULT | 기본 배달
ONLY_ONE | 한집 배달

#### PaymentMethod
- 결제 방식

타입 | 설명
--|--
CARD | 카드결제
KAKAO | 카카오페이 결제
MEET | 만나서 결제

#### PaymentStatus
- 결제 상태

타입 | 설명
--|--
COMPLETED | 결제 완료
CANCLED | 결제 취소
FAILED | 결제 실패

#### RiderRequestOption
- 라이더 요청사항 옵션

타입 | 설명
--|--
NONE | 선택 안함
SELF_RECEIVE | 직접 받을게요 (부재시 문앞)
DROP_AT_DOOR_BELL_OK | 문 앞에 놔주세요 (초인종O)
DROP_AT_DOOR_BELL_NO | 문 앞에 놔주세요 (초인종X)
CALL_ON_ARRIVAL | 도착하면 전화주세요
MESSAGE_ON_ARRIVAL | 도착하면 문자해주세요
CUSTOM_INPUT | 직접 입력하기
 
 ### 스크린샷 (선택)
 
 ## 💬리뷰 요구사항(선택)
 
- 라이더 요청사항 옵션 enum에서 필드 네이밍이 적절한지 확인해주세요!
