### PR TITLE
[Feature] 메뉴 조회 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -59,7 +59,7 @@ dependencies {
      */
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
-    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.9'
     implementation "org.springframework.boot:spring-boot-docker-compose"
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'io.jsonwebtoken:jjwt-api:0.12.6'

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -5,7 +5,7 @@ services:
     image: mysql:latest
     container_name: mysql
     ports:
-      - 3306:3306
+      - 3307:3306
     environment:
       MYSQL_DATABASE: itseats
       MYSQL_ROOT_PASSWORD: 1234

--- a/src/main/java/com/idukbaduk/itseats/menu/controller/MenuController.java
+++ b/src/main/java/com/idukbaduk/itseats/menu/controller/MenuController.java
@@ -1,0 +1,34 @@
+package com.idukbaduk.itseats.menu.controller;
+
+import com.idukbaduk.itseats.global.response.BaseResponse;
+import com.idukbaduk.itseats.menu.dto.MenuListRequest;
+import com.idukbaduk.itseats.menu.dto.MenuListResponse;
+import com.idukbaduk.itseats.menu.service.MenuService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/owner")
+@RequiredArgsConstructor
+public class MenuController {
+
+    private final MenuService menuService;
+
+    @PostMapping("/{storeId}/menus")
+    public ResponseEntity<BaseResponse> getMenuList(
+            @PathVariable Long storeId,
+            @RequestBody MenuListRequest request
+    ) {
+        MenuListRequest req = MenuListRequest.builder()
+                .storeId(storeId)
+                .menuGroup(request.getMenuGroup())
+                .keyword(request.getKeyword())
+                .build();
+
+        MenuListResponse data = menuService.getMenuList(req);
+        return BaseResponse.toResponseEntity(HttpStatus.OK,"메뉴 목록 조회 성공", data);
+    }
+
+}

--- a/src/main/java/com/idukbaduk/itseats/menu/controller/MenuController.java
+++ b/src/main/java/com/idukbaduk/itseats/menu/controller/MenuController.java
@@ -21,13 +21,7 @@ public class MenuController {
             @PathVariable Long storeId,
             @RequestBody MenuListRequest request
     ) {
-        MenuListRequest req = MenuListRequest.builder()
-                .storeId(storeId)
-                .menuGroup(request.getMenuGroup())
-                .keyword(request.getKeyword())
-                .build();
-
-        MenuListResponse data = menuService.getMenuList(req);
+        MenuListResponse data = menuService.getMenuList(storeId, request);
         return BaseResponse.toResponseEntity(HttpStatus.OK,"메뉴 목록 조회 성공", data);
     }
 

--- a/src/main/java/com/idukbaduk/itseats/menu/dto/MenuInfoDto.java
+++ b/src/main/java/com/idukbaduk/itseats/menu/dto/MenuInfoDto.java
@@ -1,0 +1,18 @@
+package com.idukbaduk.itseats.menu.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class MenuInfoDto {
+    private Long menuId;
+    private String menuName;
+    private String menuPrice;
+    private String menuStatus;
+    private String menuGroupName;
+}

--- a/src/main/java/com/idukbaduk/itseats/menu/dto/MenuListRequest.java
+++ b/src/main/java/com/idukbaduk/itseats/menu/dto/MenuListRequest.java
@@ -10,7 +10,6 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class MenuListRequest {
-    private Long storeId;
     private String menuGroup;
     private String keyword;
 }

--- a/src/main/java/com/idukbaduk/itseats/menu/dto/MenuListRequest.java
+++ b/src/main/java/com/idukbaduk/itseats/menu/dto/MenuListRequest.java
@@ -1,0 +1,16 @@
+package com.idukbaduk.itseats.menu.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class MenuListRequest {
+    private Long storeId;
+    private String menuGroup;
+    private String keyword;
+}

--- a/src/main/java/com/idukbaduk/itseats/menu/dto/MenuListResponse.java
+++ b/src/main/java/com/idukbaduk/itseats/menu/dto/MenuListResponse.java
@@ -1,0 +1,17 @@
+package com.idukbaduk.itseats.menu.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class MenuListResponse {
+
+    private int totalMenuCount;
+    private int orderableMenuCount;
+    private int outOfStockTodayCount;
+    private int hiddenMenuCount;
+    private List<MenuInfoDto> menus;
+}

--- a/src/main/java/com/idukbaduk/itseats/menu/entity/Menu.java
+++ b/src/main/java/com/idukbaduk/itseats/menu/entity/Menu.java
@@ -54,6 +54,4 @@ public class Menu extends BaseEntity {
     @Column(name = "menu_priority", nullable = false)
     private int menuPriority;
 
-    @Column(name = "is_deleted", nullable = false)
-    private boolean isDeleted;
 }

--- a/src/main/java/com/idukbaduk/itseats/menu/error/MenuErrorCode.java
+++ b/src/main/java/com/idukbaduk/itseats/menu/error/MenuErrorCode.java
@@ -9,8 +9,6 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum MenuErrorCode implements ErrorCode {
     MENU_NOT_FOUND(HttpStatus.NOT_FOUND,"메뉴를 찾을 수 없습니다."),
-    INVALID_MENU_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 메뉴 요청입니다."),
-    STORE_ID_REQUIRED(HttpStatus.BAD_REQUEST, "storeId는 필수입니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/idukbaduk/itseats/menu/error/MenuErrorCode.java
+++ b/src/main/java/com/idukbaduk/itseats/menu/error/MenuErrorCode.java
@@ -1,0 +1,28 @@
+package com.idukbaduk.itseats.menu.error;
+
+import com.idukbaduk.itseats.global.error.core.ErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum MenuErrorCode implements ErrorCode {
+    MENU_NOT_FOUND(HttpStatus.NOT_FOUND,"메뉴를 찾을 수 없습니다."),
+    INVALID_MENU_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 메뉴 요청입니다."),
+    STORE_ID_REQUIRED(HttpStatus.BAD_REQUEST, "storeId는 필수입니다."),
+    ;
+
+    private final HttpStatus httpStatus;
+    private final String message;
+
+    @Override
+    public HttpStatus getStatus() {
+        return httpStatus;
+    }
+
+    @Override
+    public String getMessage() {
+        return "[MENU ERROR] " + message;
+    }
+}

--- a/src/main/java/com/idukbaduk/itseats/menu/error/MenuException.java
+++ b/src/main/java/com/idukbaduk/itseats/menu/error/MenuException.java
@@ -1,0 +1,11 @@
+package com.idukbaduk.itseats.menu.error;
+
+import com.idukbaduk.itseats.global.error.core.BaseException;
+import com.idukbaduk.itseats.global.error.core.ErrorCode;
+
+public class MenuException extends BaseException {
+
+    public MenuException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/idukbaduk/itseats/menu/repository/MenuRepository.java
+++ b/src/main/java/com/idukbaduk/itseats/menu/repository/MenuRepository.java
@@ -1,0 +1,22 @@
+package com.idukbaduk.itseats.menu.repository;
+
+import com.idukbaduk.itseats.menu.entity.Menu;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface MenuRepository extends JpaRepository<Menu, Long> {
+
+    @Query("SELECT m FROM Menu m " +
+            "JOIN FETCH m.menuGroup mg " +
+            "WHERE mg.store.storeId = :storeId " +
+            "AND (:menuGroup IS NULL OR m.menuGroup.menuGroupName = :menuGroup) " +
+            "AND (:keyword IS NULL OR m.menuName LIKE %:keyword%)")
+    List<Menu> findMenusByStore(
+            @Param("storeId") Long storeId,
+            @Param("menuGroup") String menuGroup,
+            @Param("keyword") String keyword
+    );
+}

--- a/src/main/java/com/idukbaduk/itseats/menu/repository/MenuRepository.java
+++ b/src/main/java/com/idukbaduk/itseats/menu/repository/MenuRepository.java
@@ -13,7 +13,7 @@ public interface MenuRepository extends JpaRepository<Menu, Long> {
             "JOIN FETCH m.menuGroup mg " +
             "WHERE mg.store.storeId = :storeId " +
             "AND (:menuGroup IS NULL OR m.menuGroup.menuGroupName = :menuGroup) " +
-            "AND (:keyword IS NULL OR m.menuName LIKE %:keyword%)")
+            "AND (:keyword IS NULL OR m.menuName LIKE CONCAT('%', :keyword, '%'))")
     List<Menu> findMenusByStore(
             @Param("storeId") Long storeId,
             @Param("menuGroup") String menuGroup,

--- a/src/main/java/com/idukbaduk/itseats/menu/service/MenuService.java
+++ b/src/main/java/com/idukbaduk/itseats/menu/service/MenuService.java
@@ -20,13 +20,10 @@ public class MenuService {
 
     private final MenuRepository menuRepository;
 
-    public MenuListResponse getMenuList(MenuListRequest request) {
-        if (request.getStoreId() == null) {
-            throw new MenuException(MenuErrorCode.STORE_ID_REQUIRED);
-        }
+    public MenuListResponse getMenuList(Long storeId, MenuListRequest request) {
 
         List<Menu> menus = menuRepository.findMenusByStore(
-                request.getStoreId(),
+                storeId,
                 request.getMenuGroup(),
                 request.getKeyword()
         );
@@ -36,15 +33,9 @@ public class MenuService {
         }
 
         int totalMenuCount = menus.size();
-        int orderableMenuCount = (int) menus.stream()
-                .filter(m -> m.getMenuStatus() == MenuStatus.ON_SALE)
-                .count();
-        int outOfStockTodayCount = (int) menus.stream()
-                .filter(m -> m.getMenuStatus() == MenuStatus.OUT_OF_STOCK)
-                .count();
-        int hiddenMenuCount = (int) menus.stream()
-                .filter(m -> m.getMenuStatus() == MenuStatus.HIDDEN)
-                .count();
+        int orderableMenuCount = getMenuCount(menus, MenuStatus.ON_SALE);
+        int outOfStockTodayCount = getMenuCount(menus, MenuStatus.OUT_OF_STOCK);
+        int hiddenMenuCount = getMenuCount(menus, MenuStatus.HIDDEN);
 
         List<MenuInfoDto> menuInfos = menus.stream()
                 .map(menu -> MenuInfoDto.builder()
@@ -63,5 +54,11 @@ public class MenuService {
                 .hiddenMenuCount(hiddenMenuCount)
                 .menus(menuInfos)
                 .build();
+    }
+
+    private int getMenuCount(List<Menu> menus, MenuStatus menuStatus) {
+        return (int) menus.stream()
+                .filter(m -> m.getMenuStatus() == menuStatus)
+                .count();
     }
 }

--- a/src/main/java/com/idukbaduk/itseats/menu/service/MenuService.java
+++ b/src/main/java/com/idukbaduk/itseats/menu/service/MenuService.java
@@ -1,0 +1,67 @@
+package com.idukbaduk.itseats.menu.service;
+
+import com.idukbaduk.itseats.menu.dto.MenuInfoDto;
+import com.idukbaduk.itseats.menu.dto.MenuListRequest;
+import com.idukbaduk.itseats.menu.dto.MenuListResponse;
+import com.idukbaduk.itseats.menu.entity.Menu;
+import com.idukbaduk.itseats.menu.entity.enums.MenuStatus;
+import com.idukbaduk.itseats.menu.error.MenuErrorCode;
+import com.idukbaduk.itseats.menu.error.MenuException;
+import com.idukbaduk.itseats.menu.repository.MenuRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class MenuService {
+
+    private final MenuRepository menuRepository;
+
+    public MenuListResponse getMenuList(MenuListRequest request) {
+        if (request.getStoreId() == null) {
+            throw new MenuException(MenuErrorCode.STORE_ID_REQUIRED);
+        }
+
+        List<Menu> menus = menuRepository.findMenusByStore(
+                request.getStoreId(),
+                request.getMenuGroup(),
+                request.getKeyword()
+        );
+
+        if (menus.isEmpty()) {
+            throw new MenuException(MenuErrorCode.MENU_NOT_FOUND);
+        }
+
+        int totalMenuCount = menus.size();
+        int orderableMenuCount = (int) menus.stream()
+                .filter(m -> m.getMenuStatus() == MenuStatus.ON_SALE)
+                .count();
+        int outOfStockTodayCount = (int) menus.stream()
+                .filter(m -> m.getMenuStatus() == MenuStatus.OUT_OF_STOCK)
+                .count();
+        int hiddenMenuCount = (int) menus.stream()
+                .filter(m -> m.getMenuStatus() == MenuStatus.HIDDEN)
+                .count();
+
+        List<MenuInfoDto> menuInfos = menus.stream()
+                .map(menu -> MenuInfoDto.builder()
+                        .menuId(menu.getMenuId())
+                        .menuName(menu.getMenuName())
+                        .menuPrice(String.valueOf(menu.getMenuPrice()))
+                        .menuStatus(menu.getMenuStatus().name())
+                        .menuGroupName(menu.getMenuGroup().getMenuGroupName())
+                        .build())
+                .toList();
+
+        return MenuListResponse.builder()
+                .totalMenuCount(totalMenuCount)
+                .orderableMenuCount(orderableMenuCount)
+                .outOfStockTodayCount(outOfStockTodayCount)
+                .hiddenMenuCount(hiddenMenuCount)
+                .menus(menuInfos)
+                .build();
+    }
+}

--- a/src/test/java/com/idukbaduk/itseats/menu/service/MenuServiceTest.java
+++ b/src/test/java/com/idukbaduk/itseats/menu/service/MenuServiceTest.java
@@ -1,0 +1,114 @@
+package com.idukbaduk.itseats.menu.service;
+
+import com.idukbaduk.itseats.menu.dto.MenuInfoDto;
+import com.idukbaduk.itseats.menu.dto.MenuListRequest;
+import com.idukbaduk.itseats.menu.dto.MenuListResponse;
+import com.idukbaduk.itseats.menu.entity.Menu;
+import com.idukbaduk.itseats.menu.entity.MenuGroup;
+import com.idukbaduk.itseats.menu.entity.enums.MenuStatus;
+import com.idukbaduk.itseats.menu.error.MenuErrorCode;
+import com.idukbaduk.itseats.menu.error.MenuException;
+import com.idukbaduk.itseats.menu.repository.MenuRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class MenuServiceTest {
+
+    @Mock
+    private MenuRepository menuRepository;
+
+    @InjectMocks
+    private MenuService menuService;
+
+    @Test
+    @DisplayName("storeId가 null이면 예외 발생")
+    void getMenuList_storeIdNull_throwsException() {
+        // given
+        MenuListRequest request = MenuListRequest.builder()
+                .storeId(null)
+                .build();
+
+        // when & then
+        assertThatThrownBy(() -> menuService.getMenuList(request))
+                .isInstanceOf(MenuException.class)
+                .hasMessageContaining(MenuErrorCode.STORE_ID_REQUIRED.getMessage());
+    }
+
+    @Test
+    @DisplayName("메뉴가 없으면 예외 발생")
+    void getMenuList_noMenus_throwsException() {
+        // given
+        Long storeId = 1L;
+        MenuListRequest request = MenuListRequest.builder()
+                .storeId(storeId)
+                .build();
+
+        when(menuRepository.findMenusByStore(eq(storeId), any(), any()))
+                .thenReturn(Collections.emptyList());
+
+        // when & then
+        assertThatThrownBy(() -> menuService.getMenuList(request))
+                .isInstanceOf(MenuException.class)
+                .hasMessageContaining(MenuErrorCode.MENU_NOT_FOUND.getMessage());
+    }
+
+    @Test
+    @DisplayName("정상적으로 메뉴 목록을 반환한다")
+    void getMenuList_success() {
+        // given
+        Long storeId = 1L;
+        MenuGroup menuGroup = MenuGroup.builder()
+                .menuGroupId(10L)
+                .menuGroupName("음료")
+                .build();
+
+        Menu menu1 = Menu.builder()
+                .menuId(11L)
+                .menuName("아메리카노")
+                .menuPrice(2000)
+                .menuStatus(MenuStatus.ON_SALE)
+                .menuGroup(menuGroup)
+                .build();
+
+        Menu menu2 = Menu.builder()
+                .menuId(12L)
+                .menuName("초코라떼")
+                .menuPrice(2500)
+                .menuStatus(MenuStatus.OUT_OF_STOCK)
+                .menuGroup(menuGroup)
+                .build();
+
+        List<Menu> mockMenus = Arrays.asList(menu1, menu2);
+
+        MenuListRequest request = MenuListRequest.builder()
+                .storeId(storeId)
+                .menuGroup("음료")
+                .keyword("라떼")
+                .build();
+
+        when(menuRepository.findMenusByStore(storeId, "음료", "라떼"))
+                .thenReturn(mockMenus);
+
+        // when
+        MenuListResponse response = menuService.getMenuList(request);
+
+        // then
+        assertThat(response.getTotalMenuCount()).isEqualTo(2);
+        assertThat(response.getOrderableMenuCount()).isEqualTo(1);
+        assertThat(response.getOutOfStockTodayCount()).isEqualTo(1);
+        assertThat(response.getMenus()).extracting(MenuInfoDto::getMenuName)
+                .containsExactly("아메리카노", "초코라떼");
+    }
+}

--- a/src/test/java/com/idukbaduk/itseats/menu/service/MenuServiceTest.java
+++ b/src/test/java/com/idukbaduk/itseats/menu/service/MenuServiceTest.java
@@ -33,33 +33,19 @@ class MenuServiceTest {
     private MenuService menuService;
 
     @Test
-    @DisplayName("storeId가 null이면 예외 발생")
-    void getMenuList_storeIdNull_throwsException() {
-        // given
-        MenuListRequest request = MenuListRequest.builder()
-                .storeId(null)
-                .build();
-
-        // when & then
-        assertThatThrownBy(() -> menuService.getMenuList(request))
-                .isInstanceOf(MenuException.class)
-                .hasMessageContaining(MenuErrorCode.STORE_ID_REQUIRED.getMessage());
-    }
-
-    @Test
     @DisplayName("메뉴가 없으면 예외 발생")
     void getMenuList_noMenus_throwsException() {
         // given
         Long storeId = 1L;
         MenuListRequest request = MenuListRequest.builder()
-                .storeId(storeId)
+                // storeId 필드 제거
                 .build();
 
         when(menuRepository.findMenusByStore(eq(storeId), any(), any()))
                 .thenReturn(Collections.emptyList());
 
         // when & then
-        assertThatThrownBy(() -> menuService.getMenuList(request))
+        assertThatThrownBy(() -> menuService.getMenuList(storeId, request))
                 .isInstanceOf(MenuException.class)
                 .hasMessageContaining(MenuErrorCode.MENU_NOT_FOUND.getMessage());
     }
@@ -93,7 +79,7 @@ class MenuServiceTest {
         List<Menu> mockMenus = Arrays.asList(menu1, menu2);
 
         MenuListRequest request = MenuListRequest.builder()
-                .storeId(storeId)
+                // storeId 필드 제거
                 .menuGroup("음료")
                 .keyword("라떼")
                 .build();
@@ -102,7 +88,7 @@ class MenuServiceTest {
                 .thenReturn(mockMenus);
 
         // when
-        MenuListResponse response = menuService.getMenuList(request);
+        MenuListResponse response = menuService.getMenuList(storeId, request);
 
         // then
         assertThat(response.getTotalMenuCount()).isEqualTo(2);
@@ -112,3 +98,4 @@ class MenuServiceTest {
                 .containsExactly("아메리카노", "초코라떼");
     }
 }
+


### PR DESCRIPTION
## #️⃣연관된 이슈

#46 

## 📝작업 내용

- MenuDto (MenuListRequest, MenuListResponse, MenuInfoDto) 구현완료
- MenuRepository 구현완료
- MenuService, MenuErrorCode, MenuException 구현완료
- MenuController 구현완료
- MenuServiceTest 구현 및 작동 확인 완료

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 메뉴 목록을 조회할 수 있는 REST API 엔드포인트가 추가되었습니다.
  - 메뉴 목록 요청 및 응답을 위한 데이터 전송 객체(DTO)가 도입되었습니다.
  - 메뉴 관련 오류 코드와 예외 처리 기능이 추가되었습니다.

- **버그 수정**
  - MySQL 컨테이너의 포트가 3306에서 3307로 변경되어 포트 충돌 문제가 방지됩니다.

- **기타**
  - 메뉴 엔터티에서 isDeleted 필드가 제거되었습니다.
  - 메뉴 서비스 및 레포지토리 계층이 새롭게 추가되었습니다.
  - 관련 단위 테스트가 도입되어 서비스 동작이 검증됩니다.
  - 오픈 API UI 라이브러리 버전이 업데이트되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->