### PR TITLE
[Feature] 주문 정보 상세 조회 API 구현

### DIFF
--- a/src/main/java/com/idukbaduk/itseats/order/controller/OrderController.java
+++ b/src/main/java/com/idukbaduk/itseats/order/controller/OrderController.java
@@ -1,0 +1,34 @@
+package com.idukbaduk.itseats.order.controller;
+
+import com.idukbaduk.itseats.global.response.BaseResponse;
+import com.idukbaduk.itseats.order.dto.OrderNewRequest;
+import com.idukbaduk.itseats.order.dto.enums.OrderResponse;
+import com.idukbaduk.itseats.order.service.OrderService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/orders")
+@RequiredArgsConstructor
+public class OrderController {
+
+    private final OrderService orderService;
+
+    @PostMapping("/new")
+    public ResponseEntity<BaseResponse> getOrderNew(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @RequestBody @Validated OrderNewRequest orderNewRequest) {
+        return BaseResponse.toResponseEntity(
+                OrderResponse.SUCCESS_ORDER_DETAILS,
+                orderService.getOrderNew(userDetails.getUsername(), orderNewRequest)
+        );
+    }
+}

--- a/src/main/java/com/idukbaduk/itseats/order/dto/MenuOptionDTO.java
+++ b/src/main/java/com/idukbaduk/itseats/order/dto/MenuOptionDTO.java
@@ -1,0 +1,9 @@
+package com.idukbaduk.itseats.order.dto;
+
+import java.util.List;
+
+public class MenuOptionDTO {
+
+    private String optionGroupName;
+    private List<OptionDTO> options;
+}

--- a/src/main/java/com/idukbaduk/itseats/order/dto/MenuOptionDTO.java
+++ b/src/main/java/com/idukbaduk/itseats/order/dto/MenuOptionDTO.java
@@ -1,7 +1,12 @@
 package com.idukbaduk.itseats.order.dto;
 
+import lombok.Builder;
+import lombok.Getter;
+
 import java.util.List;
 
+@Getter
+@Builder
 public class MenuOptionDTO {
 
     private String optionGroupName;

--- a/src/main/java/com/idukbaduk/itseats/order/dto/OptionDTO.java
+++ b/src/main/java/com/idukbaduk/itseats/order/dto/OptionDTO.java
@@ -1,5 +1,10 @@
 package com.idukbaduk.itseats.order.dto;
 
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
 public class OptionDTO {
 
     private String optionName;

--- a/src/main/java/com/idukbaduk/itseats/order/dto/OptionDTO.java
+++ b/src/main/java/com/idukbaduk/itseats/order/dto/OptionDTO.java
@@ -1,0 +1,7 @@
+package com.idukbaduk.itseats.order.dto;
+
+public class OptionDTO {
+
+    private String optionName;
+    private int optionPrice;
+}

--- a/src/main/java/com/idukbaduk/itseats/order/dto/OrderMenuDTO.java
+++ b/src/main/java/com/idukbaduk/itseats/order/dto/OrderMenuDTO.java
@@ -1,0 +1,15 @@
+package com.idukbaduk.itseats.order.dto;
+
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class OrderMenuDTO {
+
+    private Long menuId;
+    private String menuName;
+    private List<MenuOptionDTO> menuOption;
+    private int menuTotalPrice;
+    private int quantity;
+}

--- a/src/main/java/com/idukbaduk/itseats/order/dto/OrderMenuDTO.java
+++ b/src/main/java/com/idukbaduk/itseats/order/dto/OrderMenuDTO.java
@@ -1,10 +1,12 @@
 package com.idukbaduk.itseats.order.dto;
 
+import lombok.Builder;
 import lombok.Getter;
 
 import java.util.List;
 
 @Getter
+@Builder
 public class OrderMenuDTO {
 
     private Long menuId;

--- a/src/main/java/com/idukbaduk/itseats/order/dto/OrderNewRequest.java
+++ b/src/main/java/com/idukbaduk/itseats/order/dto/OrderNewRequest.java
@@ -1,10 +1,12 @@
 package com.idukbaduk.itseats.order.dto;
 
+import lombok.Builder;
 import lombok.Getter;
 
 import java.util.List;
 
 @Getter
+@Builder
 public class OrderNewRequest {
 
     private Long addrId;

--- a/src/main/java/com/idukbaduk/itseats/order/dto/OrderNewRequest.java
+++ b/src/main/java/com/idukbaduk/itseats/order/dto/OrderNewRequest.java
@@ -1,0 +1,15 @@
+package com.idukbaduk.itseats.order.dto;
+
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class OrderNewRequest {
+
+    private Long addrId;
+    private Long storeId;
+    private List<OrderMenuDTO> orderMenus;
+    private List<Long> coupons;
+    private String deliveryType;
+}

--- a/src/main/java/com/idukbaduk/itseats/order/dto/OrderNewResponse.java
+++ b/src/main/java/com/idukbaduk/itseats/order/dto/OrderNewResponse.java
@@ -1,0 +1,18 @@
+package com.idukbaduk.itseats.order.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class OrderNewResponse {
+
+    private int defaultTImeMin;
+    private int defaultTImeMax;
+    private int onlyOneTimeMin;
+    private int onlyOneTimeMax;
+    private int orderPrice;
+    private int deliveryFee;
+    private int discountValue;
+    private int totalCost;
+}

--- a/src/main/java/com/idukbaduk/itseats/order/dto/enums/OrderResponse.java
+++ b/src/main/java/com/idukbaduk/itseats/order/dto/enums/OrderResponse.java
@@ -1,0 +1,24 @@
+package com.idukbaduk.itseats.order.dto.enums;
+
+import com.idukbaduk.itseats.global.response.Response;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@RequiredArgsConstructor
+public enum OrderResponse implements Response {
+
+    SUCCESS_ORDER_DETAILS(HttpStatus.OK, "주문 정보 상세 조회 성공");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return httpStatus;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+}

--- a/src/main/java/com/idukbaduk/itseats/order/entity/Order.java
+++ b/src/main/java/com/idukbaduk/itseats/order/entity/Order.java
@@ -3,6 +3,7 @@ package com.idukbaduk.itseats.order.entity;
 import com.idukbaduk.itseats.global.BaseEntity;
 import com.idukbaduk.itseats.member.entity.Member;
 import com.idukbaduk.itseats.order.entity.enums.OrderStatus;
+import com.idukbaduk.itseats.order.entity.enums.DeliveryType;
 import com.idukbaduk.itseats.rider.entity.Rider;
 import com.idukbaduk.itseats.store.entity.Store;
 import jakarta.persistence.Column;
@@ -58,6 +59,10 @@ public class Order extends BaseEntity {
     @Enumerated(EnumType.STRING)
     @Column(name = "order_status", nullable = false)
     private OrderStatus orderStatus;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "delivery_type", nullable = false)
+    private DeliveryType deliveryType;
 
     @Column(name = "delivery_eta", nullable = false)
     private LocalDateTime deliveryEta;

--- a/src/main/java/com/idukbaduk/itseats/order/entity/Order.java
+++ b/src/main/java/com/idukbaduk/itseats/order/entity/Order.java
@@ -21,7 +21,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.awt.*;
+import org.springframework.data.geo.Point;
 import java.time.LocalDateTime;
 
 @Entity

--- a/src/main/java/com/idukbaduk/itseats/order/entity/enums/DeliveryType.java
+++ b/src/main/java/com/idukbaduk/itseats/order/entity/enums/DeliveryType.java
@@ -1,4 +1,4 @@
-package com.idukbaduk.itseats.payment.entity.enums;
+package com.idukbaduk.itseats.order.entity.enums;
 
 public enum DeliveryType {
 

--- a/src/main/java/com/idukbaduk/itseats/order/error/OrderException.java
+++ b/src/main/java/com/idukbaduk/itseats/order/error/OrderException.java
@@ -1,0 +1,11 @@
+package com.idukbaduk.itseats.order.error;
+
+import com.idukbaduk.itseats.global.error.core.BaseException;
+import com.idukbaduk.itseats.global.error.core.ErrorCode;
+
+public class OrderException extends BaseException {
+
+    public OrderException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/idukbaduk/itseats/order/error/enums/OrderErrorCode.java
+++ b/src/main/java/com/idukbaduk/itseats/order/error/enums/OrderErrorCode.java
@@ -1,0 +1,25 @@
+package com.idukbaduk.itseats.order.error.enums;
+
+import com.idukbaduk.itseats.global.error.core.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@RequiredArgsConstructor
+public enum OrderErrorCode implements ErrorCode {
+
+    MENU_OPTION_SERIALIZATION_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "menuOption 직렬화 실패"),
+    ORDER_NUMBER_CREATE_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "중복되지 않는 주문번호 생성 실패");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+
+    @Override
+    public HttpStatus getStatus() {
+        return httpStatus;
+    }
+
+    @Override
+    public String getMessage() {
+        return "[ORDER ERROR] " + message;
+    }
+}

--- a/src/main/java/com/idukbaduk/itseats/order/error/enums/OrderErrorCode.java
+++ b/src/main/java/com/idukbaduk/itseats/order/error/enums/OrderErrorCode.java
@@ -7,8 +7,7 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum OrderErrorCode implements ErrorCode {
 
-    MENU_OPTION_SERIALIZATION_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "menuOption 직렬화 실패"),
-    ORDER_NUMBER_CREATE_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "중복되지 않는 주문번호 생성 실패");
+    MENU_OPTION_SERIALIZATION_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "menuOption 직렬화 실패");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/idukbaduk/itseats/order/repository/OrderMenuRepository.java
+++ b/src/main/java/com/idukbaduk/itseats/order/repository/OrderMenuRepository.java
@@ -1,0 +1,9 @@
+package com.idukbaduk.itseats.order.repository;
+
+import com.idukbaduk.itseats.order.entity.OrderMenu;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface OrderMenuRepository extends JpaRepository<OrderMenu, Long> {
+}

--- a/src/main/java/com/idukbaduk/itseats/order/repository/OrderRepository.java
+++ b/src/main/java/com/idukbaduk/itseats/order/repository/OrderRepository.java
@@ -6,39 +6,30 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
-import java.time.LocalDateTime;
-
 @Repository
 public interface OrderRepository extends JpaRepository<Order, Long> {
 
-    @Query("""
-        SELECT MIN(FUNCTION('TIMESTAMPDIFF', 'MINUTE', o.createdAt, o.modifiedAt))
-        FROM Order o
-        WHERE o.orderStatus = 'COMPLETED'
-          AND o.deliveryType = :deliveryType
-    """)
+    @Query(value = """
+        SELECT MIN(TIMESTAMPDIFF(MINUTE, created_at, modified_at))
+        FROM orders
+        WHERE order_status = 'COMPLETED'
+          AND delivery_type = :deliveryType
+    """, nativeQuery = true)
     Integer findMinDeliveryTimeByType(@Param("deliveryType") String deliveryType);
 
-    @Query("""
-        SELECT MAX(FUNCTION('TIMESTAMPDIFF', 'MINUTE', o.createdAt, o.modifiedAt))
-        FROM Order o
-        WHERE o.orderStatus = 'COMPLETED'
-          AND o.deliveryType = :deliveryType
-    """)
+    @Query(value = """
+        SELECT MAX(TIMESTAMPDIFF(MINUTE, created_at, modified_at))
+        FROM orders
+        WHERE order_status = 'COMPLETED'
+          AND delivery_type = :deliveryType
+    """, nativeQuery = true)
     Integer findMaxDeliveryTimeByType(@Param("deliveryType") String deliveryType);
 
-    @Query("""
-        SELECT AVG(FUNCTION('TIMESTAMPDIFF', 'SECOND', o.createdAt, o.modifiedAt))
-        FROM Order o
-        WHERE o.orderStatus = 'COMPLETED'
-          AND o.deliveryType = :deliveryType
-    """)
+    @Query(value = """
+        SELECT AVG(TIMESTAMPDIFF(SECOND, created_at, modified_at))
+        FROM orders
+        WHERE order_status = 'COMPLETED'
+          AND delivery_type = :deliveryType
+    """, nativeQuery = true)
     Long findAvgDeliveryTimeByType(@Param("deliveryType") String deliveryType);
-
-    @Query("""
-        SELECT o.orderNumber
-        FROM Order o
-        WHERE o.orderNumber = :orderNumber
-    """)
-    boolean existsOrderNumber(@Param("orderNumber") String orderNumber);
 }

--- a/src/main/java/com/idukbaduk/itseats/order/repository/OrderRepository.java
+++ b/src/main/java/com/idukbaduk/itseats/order/repository/OrderRepository.java
@@ -1,0 +1,44 @@
+package com.idukbaduk.itseats.order.repository;
+
+import com.idukbaduk.itseats.order.entity.Order;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+
+@Repository
+public interface OrderRepository extends JpaRepository<Order, Long> {
+
+    @Query("""
+        SELECT MIN(FUNCTION('TIMESTAMPDIFF', 'MINUTE', o.createdAt, o.modifiedAt))
+        FROM Order o
+        WHERE o.orderStatus = 'COMPLETED'
+          AND o.deliveryType = :deliveryType
+    """)
+    Integer findMinDeliveryTimeByType(@Param("deliveryType") String deliveryType);
+
+    @Query("""
+        SELECT MAX(FUNCTION('TIMESTAMPDIFF', 'MINUTE', o.createdAt, o.modifiedAt))
+        FROM Order o
+        WHERE o.orderStatus = 'COMPLETED'
+          AND o.deliveryType = :deliveryType
+    """)
+    Integer findMaxDeliveryTimeByType(@Param("deliveryType") String deliveryType);
+
+    @Query("""
+        SELECT AVG(FUNCTION('TIMESTAMPDIFF', 'SECOND', o.createdAt, o.modifiedAt))
+        FROM Order o
+        WHERE o.orderStatus = 'COMPLETED'
+          AND o.deliveryType = :deliveryType
+    """)
+    Long findAvgDeliveryTimeByType(@Param("deliveryType") String deliveryType);
+
+    @Query("""
+        SELECT o.orderNumber
+        FROM Order o
+        WHERE o.orderNumber = :orderNumber
+    """)
+    boolean existsOrderNumber(@Param("orderNumber") String orderNumber);
+}

--- a/src/main/java/com/idukbaduk/itseats/payment/entity/Payment.java
+++ b/src/main/java/com/idukbaduk/itseats/payment/entity/Payment.java
@@ -3,7 +3,6 @@ package com.idukbaduk.itseats.payment.entity;
 import com.idukbaduk.itseats.global.BaseEntity;
 import com.idukbaduk.itseats.member.entity.Member;
 import com.idukbaduk.itseats.order.entity.Order;
-import com.idukbaduk.itseats.payment.entity.enums.DeliveryType;
 import com.idukbaduk.itseats.payment.entity.enums.PaymentMethod;
 import com.idukbaduk.itseats.payment.entity.enums.PaymentStatus;
 import com.idukbaduk.itseats.payment.entity.enums.RiderRequestOption;
@@ -44,10 +43,6 @@ public class Payment extends BaseEntity {
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "order_id", nullable = false)
     private Order order;
-
-    @Enumerated(EnumType.STRING)
-    @Column(name = "delivery_type", nullable = false)
-    private DeliveryType deliveryType;
 
     @Column(name = "discount_value", nullable = false)
     private int discountValue;

--- a/src/test/java/com/idukbaduk/itseats/order/service/OrderServiceTest.java
+++ b/src/test/java/com/idukbaduk/itseats/order/service/OrderServiceTest.java
@@ -1,0 +1,194 @@
+package com.idukbaduk.itseats.order.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.idukbaduk.itseats.member.entity.Member;
+import com.idukbaduk.itseats.member.service.MemberService;
+import com.idukbaduk.itseats.memberaddress.entity.MemberAddress;
+import com.idukbaduk.itseats.memberaddress.service.MemberAddressService;
+import com.idukbaduk.itseats.menu.entity.Menu;
+import com.idukbaduk.itseats.menu.service.MenuService;
+import com.idukbaduk.itseats.order.dto.MenuOptionDTO;
+import com.idukbaduk.itseats.order.dto.OptionDTO;
+import com.idukbaduk.itseats.order.dto.OrderMenuDTO;
+import com.idukbaduk.itseats.order.dto.OrderNewRequest;
+import com.idukbaduk.itseats.order.dto.OrderNewResponse;
+import com.idukbaduk.itseats.order.entity.Order;
+import com.idukbaduk.itseats.order.entity.enums.DeliveryType;
+import com.idukbaduk.itseats.order.error.OrderException;
+import com.idukbaduk.itseats.order.error.enums.OrderErrorCode;
+import com.idukbaduk.itseats.order.repository.OrderMenuRepository;
+import com.idukbaduk.itseats.order.repository.OrderRepository;
+import com.idukbaduk.itseats.store.entity.Store;
+import com.idukbaduk.itseats.store.service.StoreService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.*;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class OrderServiceTest {
+
+    @Mock
+    private OrderRepository orderRepository;
+
+    @Mock
+    private OrderMenuRepository orderMenuRepository;
+
+    @Mock
+    private MenuService menuService;
+
+    @Mock
+    private StoreService storeService;
+
+    @Mock
+    private MemberService memberService;
+
+    @Mock
+    private MemberAddressService memberAddressService;
+
+    @InjectMocks
+    private OrderService orderService;
+
+    @BeforeEach
+    void setup() {
+        orderService = new OrderService(
+                orderRepository,
+                orderMenuRepository,
+                menuService,
+                storeService,
+                memberService,
+                memberAddressService,
+                new ObjectMapper()
+        );
+    }
+
+    @Test
+    @DisplayName("주문 정보 상세 조회 성공")
+    void getOrderNew_success() {
+        // given
+        String username = "testuser";
+        Member mockMember = Member.builder()
+                .username(username)
+                .build();
+
+        Store mockStore = Store.builder()
+                .storeId(1L)
+                .defaultDeliveryFee(3000)
+                .onlyOneDeliveryFee(3500)
+                .build();
+
+        MemberAddress mockAddress = MemberAddress.builder()
+                .addressId(1L)
+                .mainAddress("서울시 구름구 구름로100번길 10")
+                .detailAddress("100호")
+                .build();
+
+        OrderMenuDTO orderMenuDTO1 = OrderMenuDTO.builder()
+                .menuId(1L)
+                .menuName("아메리카노")
+                .quantity(2)
+                .menuOption(
+                        List.of(MenuOptionDTO.builder()
+                                .options(List.of(OptionDTO.builder()
+                                        .optionPrice(1000)
+                                        .build()))
+                        .build()))
+                .menuTotalPrice(2000)
+                .build();
+        OrderMenuDTO orderMenuDTO2 = OrderMenuDTO.builder()
+                .menuId(2L)
+                .menuName("라떼")
+                .quantity(1)
+                .menuOption(
+                        List.of(MenuOptionDTO.builder()
+                                .options(List.of(OptionDTO.builder()
+                                        .optionPrice(500)
+                                        .build()))
+                                .build()))
+                .menuTotalPrice(3000)
+                .build();
+
+        OrderNewRequest request = OrderNewRequest.builder()
+                .addrId(1L)
+                .storeId(1L)
+                .deliveryType(DeliveryType.DEFAULT.name())
+                .orderMenus(List.of(orderMenuDTO1, orderMenuDTO2))
+                .build();
+
+        when(memberService.getMemberByUsername(username)).thenReturn(mockMember);
+        when(memberAddressService.getMemberAddress(1L)).thenReturn(mockAddress);
+        when(storeService.getStore(1L)).thenReturn(mockStore);
+        when(menuService.getMenu(1L)).thenReturn(new Menu());
+
+        when(orderRepository.findAvgDeliveryTimeByType(DeliveryType.DEFAULT.name())).thenReturn(30L);
+        when(orderRepository.findMinDeliveryTimeByType(DeliveryType.DEFAULT.name())).thenReturn(20);
+        when(orderRepository.findMaxDeliveryTimeByType(DeliveryType.DEFAULT.name())).thenReturn(40);
+        when(orderRepository.findMinDeliveryTimeByType(DeliveryType.ONLY_ONE.name())).thenReturn(25);
+        when(orderRepository.findMaxDeliveryTimeByType(DeliveryType.ONLY_ONE.name())).thenReturn(45);
+        when(orderRepository.save(any(Order.class))).thenAnswer(i -> i.getArgument(0));
+
+        // when
+        OrderNewResponse response = orderService.getOrderNew(username, request);
+
+        // then
+        assertThat(response.getOrderPrice()).isEqualTo(7000);
+        assertThat(response.getDeliveryFee()).isEqualTo(3000);
+        assertThat(response.getTotalCost()).isEqualTo(10000);
+        assertThat(response.getDefaultTImeMin()).isEqualTo(20);
+        assertThat(response.getOnlyOneTimeMax()).isEqualTo(45);
+
+        verify(orderMenuRepository).saveAll(anyList());
+    }
+
+    @Test
+    @DisplayName("ObjectMapper가 null일 때 menuOption 직렬화 실패 예외 발생")
+    void getOrderNew_serializationException() {
+        // given
+        OrderService exceptionOrderService = new OrderService(
+                orderRepository,
+                orderMenuRepository,
+                menuService,
+                storeService,
+                memberService,
+                memberAddressService,
+                null
+        );
+
+        String username = "testuser";
+
+        OrderMenuDTO menuDTO = OrderMenuDTO.builder()
+                .menuId(1L)
+                .menuName("메뉴")
+                .quantity(1)
+                .menuTotalPrice(1000)
+                .menuOption(List.of(MenuOptionDTO.builder().build()))
+                .build();
+        OrderNewRequest request = OrderNewRequest.builder()
+                .addrId(1L)
+                .storeId(1L)
+                .deliveryType(DeliveryType.DEFAULT.name())
+                .orderMenus(List.of(menuDTO))
+                .build();
+
+        when(memberService.getMemberByUsername(any())).thenReturn(Member.builder().build());
+        when(memberAddressService.getMemberAddress(any())).thenReturn(MemberAddress.builder().build());
+        when(storeService.getStore(any())).thenReturn(Store.builder().build());
+        when(menuService.getMenu(any())).thenReturn(Menu.builder().build());
+        when(orderRepository.findAvgDeliveryTimeByType(any())).thenReturn(30L);
+        when(orderRepository.save(any(Order.class))).thenAnswer(i -> i.getArgument(0));
+
+        // when & then
+        assertThatThrownBy(() -> exceptionOrderService.getOrderNew(username, request))
+                .isInstanceOf(OrderException.class)
+                .hasMessageContaining(OrderErrorCode.MENU_OPTION_SERIALIZATION_FAIL.getMessage());
+    }
+
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

#45 

## 📝작업 내용

- 주문 정보 (주문 메뉴 정보, 쿠폰 목록, 배송 타입) 를 받아와 주문 메뉴와 주문을 데이터베이스에 저장하고 결제 전 주문 상세 정보를 응답으로 반환합니다.

> 쿠폰 부분은 2차 스프린트때 구현하기 위해 주석을 남겨두고 0을 반환하도록 설정하였습니다.

---

- DTO `OrderNewRequest`, `OrderMenuDTO`, `OptionDTO`, `MenuOptionDTO`, `OrderNewResponse` 구현완료
- Repository `OrderRepository`, `OrderMenuRepository` 구현완료
- Service `OrderService` 구현완료
- Exception `OrderErrorCode`, `OrderException` 구현완료
- Controller `OrderController` 구현완료
- Test `OrderServiceTest` 구현 및 작동 확인 완료

### 스크린샷

![image](https://github.com/user-attachments/assets/e61323f7-f2b2-466c-afde-482bb106c38e)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
