### PR TITLE
[Feature] 주소 추가 API 구현

### DIFF
--- a/src/main/java/com/idukbaduk/itseats/memberaddress/controller/MemberAddressController.java
+++ b/src/main/java/com/idukbaduk/itseats/memberaddress/controller/MemberAddressController.java
@@ -14,13 +14,13 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/api/address")
+@RequestMapping("/api/addresses")
 @RequiredArgsConstructor
 public class MemberAddressController {
 
     private final MemberAddressService memberAddressService;
 
-    @PostMapping()
+    @PostMapping
     public ResponseEntity<BaseResponse> createAddress(
             @AuthenticationPrincipal UserDetails userDetails,
             @RequestBody AddressCreateRequest addressCreateRequest) {

--- a/src/main/java/com/idukbaduk/itseats/memberaddress/controller/MemberAddressController.java
+++ b/src/main/java/com/idukbaduk/itseats/memberaddress/controller/MemberAddressController.java
@@ -1,0 +1,32 @@
+package com.idukbaduk.itseats.memberaddress.controller;
+
+import com.idukbaduk.itseats.global.response.BaseResponse;
+import com.idukbaduk.itseats.memberaddress.dto.AddressCreateRequest;
+import com.idukbaduk.itseats.memberaddress.dto.enums.AddressResponse;
+import com.idukbaduk.itseats.memberaddress.service.MemberAddressService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/address")
+@RequiredArgsConstructor
+public class MemberAddressController {
+
+    private final MemberAddressService memberAddressService;
+
+    @PostMapping()
+    public ResponseEntity<BaseResponse> createAddress(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @RequestBody AddressCreateRequest addressCreateRequest) {
+        return BaseResponse.toResponseEntity(
+                AddressResponse.ADDRESS_CREATE_SUCCESS,
+                memberAddressService.createAddress(userDetails.getUsername(), addressCreateRequest)
+        );
+    }
+}

--- a/src/main/java/com/idukbaduk/itseats/memberaddress/dto/AddressCreateRequest.java
+++ b/src/main/java/com/idukbaduk/itseats/memberaddress/dto/AddressCreateRequest.java
@@ -1,0 +1,15 @@
+package com.idukbaduk.itseats.memberaddress.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class AddressCreateRequest {
+
+    private String mainAddress;
+    private String detailAddress;
+    private double locationX;
+    private double locationY;
+    private String addressCategory;
+}

--- a/src/main/java/com/idukbaduk/itseats/memberaddress/dto/AddressCreateResponse.java
+++ b/src/main/java/com/idukbaduk/itseats/memberaddress/dto/AddressCreateResponse.java
@@ -1,0 +1,13 @@
+package com.idukbaduk.itseats.memberaddress.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class AddressCreateResponse {
+
+    private String mainAddress;
+    private String detailAddress;
+    private String addressCategory;
+}

--- a/src/main/java/com/idukbaduk/itseats/memberaddress/dto/enums/AddressResponse.java
+++ b/src/main/java/com/idukbaduk/itseats/memberaddress/dto/enums/AddressResponse.java
@@ -1,0 +1,25 @@
+package com.idukbaduk.itseats.memberaddress.dto.enums;
+
+import com.idukbaduk.itseats.global.response.BaseResponse;
+import com.idukbaduk.itseats.global.response.Response;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@RequiredArgsConstructor
+public enum AddressResponse implements Response {
+
+    ADDRESS_CREATE_SUCCESS(HttpStatus.CREATED, "주소 추가 성공");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return httpStatus;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+}

--- a/src/main/java/com/idukbaduk/itseats/memberaddress/dto/enums/AddressResponse.java
+++ b/src/main/java/com/idukbaduk/itseats/memberaddress/dto/enums/AddressResponse.java
@@ -8,7 +8,7 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum AddressResponse implements Response {
 
-    ADDRESS_CREATE_SUCCESS(HttpStatus.CREATED, "주소 추가 성공");
+    CREATE_ADDRESS_SUCCESS(HttpStatus.CREATED, "주소 추가 성공");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/idukbaduk/itseats/memberaddress/service/MemberAddressService.java
+++ b/src/main/java/com/idukbaduk/itseats/memberaddress/service/MemberAddressService.java
@@ -12,6 +12,7 @@ import com.idukbaduk.itseats.memberaddress.repository.MemberAddressRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.geo.Point;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -20,6 +21,7 @@ public class MemberAddressService {
     private final MemberAddressRepository memberAddressRepository;
     private final MemberService memberService;
 
+    @Transactional
     public AddressCreateResponse createAddress(String username, AddressCreateRequest addressCreateRequest) {
         Member member = memberService.getMemberByUsername(username);
 

--- a/src/main/java/com/idukbaduk/itseats/memberaddress/service/MemberAddressService.java
+++ b/src/main/java/com/idukbaduk/itseats/memberaddress/service/MemberAddressService.java
@@ -1,10 +1,16 @@
 package com.idukbaduk.itseats.memberaddress.service;
 
+import com.idukbaduk.itseats.member.entity.Member;
+import com.idukbaduk.itseats.member.service.MemberService;
+import com.idukbaduk.itseats.memberaddress.dto.AddressCreateRequest;
+import com.idukbaduk.itseats.memberaddress.dto.AddressCreateResponse;
 import com.idukbaduk.itseats.memberaddress.entity.MemberAddress;
+import com.idukbaduk.itseats.memberaddress.entity.enums.AddressCategory;
 import com.idukbaduk.itseats.memberaddress.error.MemberAddressException;
 import com.idukbaduk.itseats.memberaddress.error.enums.MemberAddressErrorCode;
 import com.idukbaduk.itseats.memberaddress.repository.MemberAddressRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.geo.Point;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -12,6 +18,26 @@ import org.springframework.stereotype.Service;
 public class MemberAddressService {
 
     private final MemberAddressRepository memberAddressRepository;
+    private final MemberService memberService;
+
+    public AddressCreateResponse createAddress(String username, AddressCreateRequest addressCreateRequest) {
+        Member member = memberService.getMemberByUsername(username);
+
+        MemberAddress memberAddress = MemberAddress.builder()
+                .member(member)
+                .mainAddress(addressCreateRequest.getMainAddress())
+                .detailAddress(addressCreateRequest.getDetailAddress())
+                .location(new Point(addressCreateRequest.getLocationX(), addressCreateRequest.getLocationY()))
+                .addressCategory(AddressCategory.valueOf(addressCreateRequest.getAddressCategory()))
+                .build();
+        memberAddressRepository.save(memberAddress);
+
+        return AddressCreateResponse.builder()
+                .mainAddress(memberAddress.getMainAddress())
+                .detailAddress(memberAddress.getDetailAddress())
+                .addressCategory(memberAddress.getAddressCategory().name())
+                .build();
+    }
 
     public MemberAddress getMemberAddress(Long addressId) {
         return memberAddressRepository.findById(addressId)

--- a/src/test/java/com/idukbaduk/itseats/memberaddress/service/MemberAddressServiceTest.java
+++ b/src/test/java/com/idukbaduk/itseats/memberaddress/service/MemberAddressServiceTest.java
@@ -1,20 +1,27 @@
 package com.idukbaduk.itseats.memberaddress.service;
 
+import com.idukbaduk.itseats.member.entity.Member;
+import com.idukbaduk.itseats.member.service.MemberService;
+import com.idukbaduk.itseats.memberaddress.dto.AddressCreateRequest;
+import com.idukbaduk.itseats.memberaddress.dto.AddressCreateResponse;
 import com.idukbaduk.itseats.memberaddress.entity.MemberAddress;
+import com.idukbaduk.itseats.memberaddress.entity.enums.AddressCategory;
 import com.idukbaduk.itseats.memberaddress.error.MemberAddressException;
 import com.idukbaduk.itseats.memberaddress.error.enums.MemberAddressErrorCode;
 import com.idukbaduk.itseats.memberaddress.repository.MemberAddressRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
+import org.mockito.*;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.geo.Point;
 
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -23,8 +30,58 @@ class MemberAddressServiceTest {
     @Mock
     private MemberAddressRepository memberAddressRepository;
 
+    @Mock
+    private MemberService memberService;
+
     @InjectMocks
     private MemberAddressService memberAddressService;
+
+    @Test
+    @DisplayName("주소 추가 성공")
+    void createAddress_success() {
+        // given
+        String mainAddress = "서울시 구름구 구름로100번길 10";
+        String detailsAddress = "100호";
+        double locationX = 126.9780;
+        double locationY = 37.5665;
+        String addressCategory = AddressCategory.HOUSE.name();
+
+        Member mockMember = Member.builder().username("user01").build();
+        AddressCreateRequest request = AddressCreateRequest.builder()
+                .mainAddress(mainAddress)
+                .detailAddress(detailsAddress)
+                .locationX(locationX)
+                .locationY(locationY)
+                .addressCategory(addressCategory)
+                .build();
+
+        when(memberService.getMemberByUsername(any())).thenReturn(mockMember);
+        when(memberAddressRepository.save(any(MemberAddress.class))).thenAnswer(i -> i.getArgument(0));
+
+        ArgumentCaptor<MemberAddress> captor = ArgumentCaptor.forClass(MemberAddress.class);
+
+        // when
+        AddressCreateResponse response = memberAddressService.createAddress(mockMember.getUsername(), request);
+
+        // then - response
+        assertThat(response).isNotNull();
+        assertThat(response.getAddressCategory()).isEqualTo(addressCategory);
+        assertThat(response.getMainAddress()).isEqualTo(mainAddress);
+        assertThat(response.getDetailAddress()).isEqualTo(detailsAddress);
+
+        // then - save
+        verify(memberAddressRepository).save(captor.capture());
+        MemberAddress savedAddress = captor.getValue();
+
+        assertThat(mockMember).isEqualTo(savedAddress.getMember());
+        assertThat(mainAddress).isEqualTo(savedAddress.getMainAddress());
+        assertThat(detailsAddress).isEqualTo(savedAddress.getDetailAddress());
+        assertThat(addressCategory).isEqualTo(savedAddress.getAddressCategory().name());
+
+        Point point = savedAddress.getLocation();
+        assertThat(point.getX()).isEqualTo(locationX);
+        assertThat(point.getY()).isEqualTo(locationY);
+    }
 
     @Test
     @DisplayName("회원 주소 정보를 성공적으로 반환")

--- a/src/test/java/com/idukbaduk/itseats/memberaddress/service/MemberAddressServiceTest.java
+++ b/src/test/java/com/idukbaduk/itseats/memberaddress/service/MemberAddressServiceTest.java
@@ -20,6 +20,7 @@ import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.within;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -70,6 +71,7 @@ class MemberAddressServiceTest {
         assertThat(response.getDetailAddress()).isEqualTo(detailsAddress);
 
         // then - save
+        verify(memberService).getMemberByUsername(mockMember.getUsername());
         verify(memberAddressRepository).save(captor.capture());
         MemberAddress savedAddress = captor.getValue();
 
@@ -79,8 +81,8 @@ class MemberAddressServiceTest {
         assertThat(addressCategory).isEqualTo(savedAddress.getAddressCategory().name());
 
         Point point = savedAddress.getLocation();
-        assertThat(point.getX()).isEqualTo(locationX);
-        assertThat(point.getY()).isEqualTo(locationY);
+        assertThat(point.getX()).isEqualTo(locationX, within(0.001));
+        assertThat(point.getY()).isEqualTo(locationY, within(0.001));
     }
 
     @Test


### PR DESCRIPTION
## #️⃣연관된 이슈

#62

## 📝작업 내용

- 주소 정보 (메인 주소, 상세 주소, 위도, 경도, 주소 타입) 를 받아와 주소를 저장하고 저장된 주소의 정보를 반환합니다.

---

- DTO  `AddressCreateRequest`, `AddressCreateResponse`, `AddressResponse` 구현완료
- Service `MemberAddressService` 구현완료
- Controller `MemberAddressController` 구현완료
- Test `MemberAddressTest` 구현 및 작동 확인 완료

### 스크린샷

![image](https://github.com/user-attachments/assets/33d1c7ed-b34c-4fc0-8522-10e6ebbfb650)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
    - 회원 주소를 추가할 수 있는 API가 도입되었습니다.
- **버그 수정**
    - 해당 없음.
- **테스트**
    - 회원 주소 생성 기능에 대한 단위 테스트가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->