### PR TITLE
[Feature] 가게 별 리뷰 목록 조회 API 구현

### DIFF
--- a/src/main/java/com/idukbaduk/itseats/review/controller/ReviewController.java
+++ b/src/main/java/com/idukbaduk/itseats/review/controller/ReviewController.java
@@ -1,0 +1,26 @@
+package com.idukbaduk.itseats.review.controller;
+
+import com.idukbaduk.itseats.global.response.BaseResponse;
+import com.idukbaduk.itseats.review.dto.StoreReviewResponse;
+import com.idukbaduk.itseats.review.service.ReviewService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/reviews")
+public class ReviewController {
+
+    private final ReviewService reviewService;
+
+    @GetMapping("/{storeId}")
+    public ResponseEntity<BaseResponse> getStoreReviews(@PathVariable Long storeId) {
+        StoreReviewResponse response = reviewService.getReviewsByStore(storeId);
+        return BaseResponse.toResponseEntity(HttpStatus.OK, "가게 별 리뷰 목록 조회 성공", response);
+    }
+}

--- a/src/main/java/com/idukbaduk/itseats/review/dto/StoreReviewDto.java
+++ b/src/main/java/com/idukbaduk/itseats/review/dto/StoreReviewDto.java
@@ -1,0 +1,14 @@
+package com.idukbaduk.itseats.review.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class StoreReviewDto {
+    private String imageUrl;
+    private String reviewer;
+    private double rating;
+    private String content;
+    private String createdAt;
+}

--- a/src/main/java/com/idukbaduk/itseats/review/dto/StoreReviewResponse.java
+++ b/src/main/java/com/idukbaduk/itseats/review/dto/StoreReviewResponse.java
@@ -1,0 +1,12 @@
+package com.idukbaduk.itseats.review.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class StoreReviewResponse {
+    private List<StoreReviewDto> reviews;
+}

--- a/src/main/java/com/idukbaduk/itseats/review/entity/Review.java
+++ b/src/main/java/com/idukbaduk/itseats/review/entity/Review.java
@@ -23,6 +23,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDateTime;
+
 @Entity
 @Getter
 @Builder

--- a/src/main/java/com/idukbaduk/itseats/review/error/ReviewErrorCode.java
+++ b/src/main/java/com/idukbaduk/itseats/review/error/ReviewErrorCode.java
@@ -21,6 +21,6 @@ public enum ReviewErrorCode implements ErrorCode {
 
     @Override
     public String getMessage() {
-        return "[MENU ERROR] " + message;
+        return "[REVIEW ERROR] " + message;
     }
 }

--- a/src/main/java/com/idukbaduk/itseats/review/error/ReviewErrorCode.java
+++ b/src/main/java/com/idukbaduk/itseats/review/error/ReviewErrorCode.java
@@ -1,0 +1,26 @@
+package com.idukbaduk.itseats.review.error;
+
+import com.idukbaduk.itseats.global.error.core.ErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum ReviewErrorCode implements ErrorCode {
+    REVIEW_NOT_FOUND(HttpStatus.NOT_FOUND, "리뷰가 없습니다."),
+    ;
+
+    private final HttpStatus httpStatus;
+    private final String message;
+
+    @Override
+    public HttpStatus getStatus() {
+        return httpStatus;
+    }
+
+    @Override
+    public String getMessage() {
+        return "[MENU ERROR] " + message;
+    }
+}

--- a/src/main/java/com/idukbaduk/itseats/review/error/ReviewException.java
+++ b/src/main/java/com/idukbaduk/itseats/review/error/ReviewException.java
@@ -1,0 +1,11 @@
+package com.idukbaduk.itseats.review.error;
+
+import com.idukbaduk.itseats.global.error.core.BaseException;
+import com.idukbaduk.itseats.global.error.core.ErrorCode;
+
+public class ReviewException extends BaseException {
+
+    public ReviewException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/idukbaduk/itseats/review/repository/ReviewImageRepository.java
+++ b/src/main/java/com/idukbaduk/itseats/review/repository/ReviewImageRepository.java
@@ -6,6 +6,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
 
 public interface ReviewImageRepository extends JpaRepository<ReviewImage, Long> {
-    List<ReviewImage> findReviewIdByInOrderByDisplayOrderAsc(List<Long> reviewIds);
+    List<ReviewImage> findByReviewIdInOrderByDisplayOrderAsc(List<Long> reviewIds);
 }
 

--- a/src/main/java/com/idukbaduk/itseats/review/repository/ReviewImageRepository.java
+++ b/src/main/java/com/idukbaduk/itseats/review/repository/ReviewImageRepository.java
@@ -1,0 +1,11 @@
+package com.idukbaduk.itseats.review.repository;
+
+import com.idukbaduk.itseats.review.entity.ReviewImage;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface ReviewImageRepository extends JpaRepository<ReviewImage, Long> {
+    List<ReviewImage> findReviewIdByInOrderByDisplayOrderAsc(List<Long> reviewIds);
+}
+

--- a/src/main/java/com/idukbaduk/itseats/review/repository/ReviewRepository.java
+++ b/src/main/java/com/idukbaduk/itseats/review/repository/ReviewRepository.java
@@ -1,0 +1,21 @@
+package com.idukbaduk.itseats.review.repository;
+
+import com.idukbaduk.itseats.review.entity.Review;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface ReviewRepository extends JpaRepository<Review, Long> {
+    @Query("SELECT r FROM Review r " +
+            "JOIN FETCH r.member WHERE r.store.storeId = :storeId " +
+            "ORDER BY r.createdAt DESC")
+    List<Review> findReviewsWithMemberByStoreId(@Param("storeId") Long storeId);
+
+    @Query("SELECT r.store.storeId, COUNT(r) " +
+            "FROM Review r WHERE r.store.storeId " +
+            "IN :storeIds GROUP BY r.store.storeId")
+    List<Object[]> countReviewsByStoreIds(@Param("storeIds") List<Long> storeIds);
+
+}

--- a/src/main/java/com/idukbaduk/itseats/review/repository/ReviewRepository.java
+++ b/src/main/java/com/idukbaduk/itseats/review/repository/ReviewRepository.java
@@ -12,10 +12,4 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
             "JOIN FETCH r.member WHERE r.store.storeId = :storeId " +
             "ORDER BY r.createdAt DESC")
     List<Review> findReviewsWithMemberByStoreId(@Param("storeId") Long storeId);
-
-    @Query("SELECT r.store.storeId, COUNT(r) " +
-            "FROM Review r WHERE r.store.storeId " +
-            "IN :storeIds GROUP BY r.store.storeId")
-    List<Object[]> countReviewsByStoreIds(@Param("storeIds") List<Long> storeIds);
-
 }

--- a/src/main/java/com/idukbaduk/itseats/review/service/ReviewService.java
+++ b/src/main/java/com/idukbaduk/itseats/review/service/ReviewService.java
@@ -30,10 +30,6 @@ public class ReviewService {
 
         List<Review> reviews = reviewRepository.findReviewsWithMemberByStoreId(storeId);
 
-        if (reviews.isEmpty()) {
-            throw new ReviewException(ReviewErrorCode.REVIEW_NOT_FOUND);
-        }
-
         List<Long> reviewIds = reviews.stream()
                 .map(Review::getReviewId)
                 .toList();

--- a/src/main/java/com/idukbaduk/itseats/review/service/ReviewService.java
+++ b/src/main/java/com/idukbaduk/itseats/review/service/ReviewService.java
@@ -1,0 +1,66 @@
+package com.idukbaduk.itseats.review.service;
+
+import com.idukbaduk.itseats.menu.error.MenuException;
+import com.idukbaduk.itseats.review.dto.StoreReviewDto;
+import com.idukbaduk.itseats.review.dto.StoreReviewResponse;
+import com.idukbaduk.itseats.review.entity.Review;
+import com.idukbaduk.itseats.review.entity.ReviewImage;
+import com.idukbaduk.itseats.review.error.ReviewErrorCode;
+import com.idukbaduk.itseats.review.error.ReviewException;
+import com.idukbaduk.itseats.review.repository.ReviewImageRepository;
+import com.idukbaduk.itseats.review.repository.ReviewRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.format.DateTimeFormatter;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+public class ReviewService {
+
+    private final ReviewRepository reviewRepository;
+    private final ReviewImageRepository reviewImageRepository;
+
+    @Transactional(readOnly = true)
+    public StoreReviewResponse getReviewsByStore(Long storeId) {
+
+        List<Review> reviews = reviewRepository.findReviewsWithMemberByStoreId(storeId);
+
+        if (reviews.isEmpty()) {
+            throw new ReviewException(ReviewErrorCode.REVIEW_NOT_FOUND);
+        }
+
+        List<Long> reviewIds = reviews.stream()
+                .map(Review::getReviewId)
+                .toList();
+
+        List<ReviewImage> images = reviewImageRepository
+                .findReviewIdByInOrderByDisplayOrderAsc(reviewIds);
+
+        Map<Long, String> reviewIdToImageUrl = new HashMap<>();
+        for (ReviewImage image : images) {
+            Long reviewId = image.getReview().getReviewId();
+            if (!reviewIdToImageUrl.containsKey(reviewId)) {
+                reviewIdToImageUrl.put(reviewId, image.getImageUrl());
+            }
+        }
+
+        List<StoreReviewDto> reviewDtos = reviews.stream()
+                .map(review -> StoreReviewDto.builder()
+                        .imageUrl(reviewIdToImageUrl.get(review.getReviewId()))
+                        .reviewer(review.getMember().getNickname())
+                        .rating(review.getStoreStar())
+                        .content(review.getContent())
+                        .createdAt(review.getCreatedAt().format(DateTimeFormatter.ISO_LOCAL_DATE_TIME))
+                        .build())
+                .toList();
+
+        return StoreReviewResponse.builder()
+                .reviews(reviewDtos)
+                .build();
+    }
+}

--- a/src/main/java/com/idukbaduk/itseats/review/service/ReviewService.java
+++ b/src/main/java/com/idukbaduk/itseats/review/service/ReviewService.java
@@ -39,7 +39,7 @@ public class ReviewService {
                 .toList();
 
         List<ReviewImage> images = reviewImageRepository
-                .findReviewIdByInOrderByDisplayOrderAsc(reviewIds);
+                .findByReviewIdInOrderByDisplayOrderAsc(reviewIds);
 
         Map<Long, String> reviewIdToImageUrl = new HashMap<>();
         for (ReviewImage image : images) {

--- a/src/test/java/com/idukbaduk/itseats/review/service/ReviewServiceTest.java
+++ b/src/test/java/com/idukbaduk/itseats/review/service/ReviewServiceTest.java
@@ -41,20 +41,6 @@ class ReviewServiceTest {
         MockitoAnnotations.openMocks(this);
     }
 
-    @DisplayName("리뷰가 없을 때 예외 발생")
-    @Test
-    void getReviewsByStore_throwsException_whenNoReviewsFound() {
-        // given
-        Long storeId = 1L;
-        when(reviewRepository.findReviewsWithMemberByStoreId(storeId))
-                .thenReturn(List.of());
-
-        // when & then
-        assertThatThrownBy(() -> reviewService.getReviewsByStore(storeId))
-                .isInstanceOf(ReviewException.class)
-                .hasFieldOrPropertyWithValue("errorCode", ReviewErrorCode.REVIEW_NOT_FOUND);
-    }
-
     @DisplayName("가게 별 리뷰 목록 조회 성공")
     @Test
     void getReviewsByStore_success() throws NoSuchFieldException, IllegalAccessException {

--- a/src/test/java/com/idukbaduk/itseats/review/service/ReviewServiceTest.java
+++ b/src/test/java/com/idukbaduk/itseats/review/service/ReviewServiceTest.java
@@ -1,0 +1,112 @@
+package com.idukbaduk.itseats.review.service;
+
+import com.idukbaduk.itseats.global.BaseEntity;
+import com.idukbaduk.itseats.review.dto.StoreReviewDto;
+import com.idukbaduk.itseats.review.dto.StoreReviewResponse;
+import com.idukbaduk.itseats.review.entity.Review;
+import com.idukbaduk.itseats.review.entity.ReviewImage;
+import com.idukbaduk.itseats.member.entity.Member;
+import com.idukbaduk.itseats.store.entity.Store;
+import com.idukbaduk.itseats.review.repository.ReviewImageRepository;
+import com.idukbaduk.itseats.review.repository.ReviewRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.lang.reflect.Field;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+class ReviewServiceTest {
+
+    @Mock
+    private ReviewRepository reviewRepository;
+    @Mock
+    private ReviewImageRepository reviewImageRepository;
+
+    @InjectMocks
+    private ReviewService reviewService;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @DisplayName("가게 별 리뷰 목록 조회 성공")
+    @Test
+    void getReviewsByStore_success() throws NoSuchFieldException, IllegalAccessException {
+        // given
+        Long storeId = 1L;
+        Member member1 = Member.builder().nickname("홍길동").build();
+        Member member2 = Member.builder().nickname("정재환").build();
+        Store store = Store.builder().storeId(storeId).build();
+
+        Review review1 = Review.builder()
+                .reviewId(100L)
+                .member(member1)
+                .store(store)
+                .storeStar(5)
+                .content("정말 맛있어요!")
+                .build();
+
+        Field field = BaseEntity.class.getDeclaredField("createdAt");
+        field.setAccessible(true);
+        field.set(review1, LocalDateTime.of(2025, 5, 5, 12, 34, 56));
+
+        Review review2 = Review.builder()
+                .reviewId(101L)
+                .member(member2)
+                .store(store)
+                .storeStar(4)
+                .content("또 먹고 싶어요!")
+                .build();
+
+        field.set(review2, LocalDateTime.of(2025, 5, 4, 12, 34, 56));
+
+        ReviewImage image1 = ReviewImage.builder()
+                .reviewImageId(1000L)
+                .review(review1)
+                .imageUrl("s3 url 1")
+                .displayOrder(1)
+                .build();
+
+        ReviewImage image2 = ReviewImage.builder()
+                .reviewImageId(1001L)
+                .review(review2)
+                .imageUrl("s3 url 2")
+                .displayOrder(1)
+                .build();
+
+        when(reviewRepository.findReviewsWithMemberByStoreId(storeId))
+                .thenReturn(List.of(review1, review2));
+        when(reviewImageRepository.findReviewIdByInOrderByDisplayOrderAsc(List.of(100L, 101L)))
+                .thenReturn(List.of(image1, image2));
+
+        // when
+        StoreReviewResponse response = reviewService.getReviewsByStore(storeId);
+
+        // then
+        assertThat(response).isNotNull();
+        assertThat(response.getReviews()).hasSize(2);
+
+        StoreReviewDto dto1 = response.getReviews().get(0);
+        assertThat(dto1.getImageUrl()).isEqualTo("s3 url 1");
+        assertThat(dto1.getReviewer()).isEqualTo("홍길동");
+        assertThat(dto1.getRating()).isEqualTo(5);
+        assertThat(dto1.getContent()).isEqualTo("정말 맛있어요!");
+        assertThat(dto1.getCreatedAt()).isEqualTo("2025-05-05T12:34:56");
+
+        StoreReviewDto dto2 = response.getReviews().get(1);
+        assertThat(dto2.getImageUrl()).isEqualTo("s3 url 2");
+        assertThat(dto2.getReviewer()).isEqualTo("정재환");
+        assertThat(dto2.getRating()).isEqualTo(4);
+        assertThat(dto2.getContent()).isEqualTo("또 먹고 싶어요!");
+        assertThat(dto2.getCreatedAt()).isEqualTo("2025-05-04T12:34:56");
+    }
+}

--- a/src/test/java/com/idukbaduk/itseats/review/service/ReviewServiceTest.java
+++ b/src/test/java/com/idukbaduk/itseats/review/service/ReviewServiceTest.java
@@ -6,6 +6,8 @@ import com.idukbaduk.itseats.review.dto.StoreReviewResponse;
 import com.idukbaduk.itseats.review.entity.Review;
 import com.idukbaduk.itseats.review.entity.ReviewImage;
 import com.idukbaduk.itseats.member.entity.Member;
+import com.idukbaduk.itseats.review.error.ReviewErrorCode;
+import com.idukbaduk.itseats.review.error.ReviewException;
 import com.idukbaduk.itseats.store.entity.Store;
 import com.idukbaduk.itseats.review.repository.ReviewImageRepository;
 import com.idukbaduk.itseats.review.repository.ReviewRepository;
@@ -21,6 +23,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.mockito.Mockito.*;
 
 class ReviewServiceTest {
@@ -36,6 +39,20 @@ class ReviewServiceTest {
     @BeforeEach
     void setUp() {
         MockitoAnnotations.openMocks(this);
+    }
+
+    @DisplayName("리뷰가 없을 때 예외 발생")
+    @Test
+    void getReviewsByStore_throwsException_whenNoReviewsFound() {
+        // given
+        Long storeId = 1L;
+        when(reviewRepository.findReviewsWithMemberByStoreId(storeId))
+                .thenReturn(List.of());
+
+        // when & then
+        assertThatThrownBy(() -> reviewService.getReviewsByStore(storeId))
+                .isInstanceOf(ReviewException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ReviewErrorCode.REVIEW_NOT_FOUND);
     }
 
     @DisplayName("가게 별 리뷰 목록 조회 성공")
@@ -85,7 +102,7 @@ class ReviewServiceTest {
 
         when(reviewRepository.findReviewsWithMemberByStoreId(storeId))
                 .thenReturn(List.of(review1, review2));
-        when(reviewImageRepository.findReviewIdByInOrderByDisplayOrderAsc(List.of(100L, 101L)))
+        when(reviewImageRepository.findByReviewIdInOrderByDisplayOrderAsc(List.of(100L, 101L)))
                 .thenReturn(List.of(image1, image2));
 
         // when


### PR DESCRIPTION
## #️⃣연관된 이슈

#66 

## 📝작업 내용

- [ ] Dto (StoreReviewDto, StoreReviewResponse) 작성
- [ ] ReviewErrorCode, ReviewException 구현
- [ ] ReviewService, ReviewController - 리뷰 목록 조회 기능 구현
- [ ] 테스트 코드 구현 및 작동 확인 완료

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 매장별 리뷰 목록 조회 API가 추가되었습니다.
  - 리뷰에는 이미지, 작성자, 평점, 내용, 작성일이 포함되어 제공됩니다.

- **테스트**
  - 리뷰 조회 서비스 동작 검증 테스트가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->