### PR TITLE
[Feature] 가게 전체 목록 조회 API 구현

### DIFF
--- a/src/main/java/com/idukbaduk/itseats/review/repository/ReviewRepository.java
+++ b/src/main/java/com/idukbaduk/itseats/review/repository/ReviewRepository.java
@@ -1,0 +1,14 @@
+package com.idukbaduk.itseats.review.repository;
+
+import com.idukbaduk.itseats.review.entity.Review;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface ReviewRepository extends JpaRepository<Review, Long> {
+    @Query("SELECT r.store.storeId, AVG(r.storeStar), COUNT(r) " +
+            "FROM Review r WHERE r.store.storeId IN :storeIds GROUP BY r.store.storeId")
+    List<Object[]> findReviewStatsByStoreIds(@Param("storeIds") List<Long> storeIds);
+}

--- a/src/main/java/com/idukbaduk/itseats/store/controller/StoreController.java
+++ b/src/main/java/com/idukbaduk/itseats/store/controller/StoreController.java
@@ -1,0 +1,25 @@
+package com.idukbaduk.itseats.store.controller;
+
+import com.idukbaduk.itseats.global.response.BaseResponse;
+import com.idukbaduk.itseats.store.dto.StoreListResponse;
+import com.idukbaduk.itseats.store.service.StoreService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/stores")
+public class StoreController {
+
+    private final StoreService storeService;
+
+    @GetMapping("/list")
+    public ResponseEntity<BaseResponse> getAllStores() {
+        StoreListResponse response = storeService.getAllStores();
+        return BaseResponse.toResponseEntity(HttpStatus.OK, "전체 가게 목록 조회 성공", response);
+    }
+}

--- a/src/main/java/com/idukbaduk/itseats/store/dto/StoreDto.java
+++ b/src/main/java/com/idukbaduk/itseats/store/dto/StoreDto.java
@@ -1,0 +1,13 @@
+package com.idukbaduk.itseats.store.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class StoreDto {
+    private String imageUrl;
+    private String name;
+    private double review;
+    private int reviewCount;
+}

--- a/src/main/java/com/idukbaduk/itseats/store/dto/StoreListResponse.java
+++ b/src/main/java/com/idukbaduk/itseats/store/dto/StoreListResponse.java
@@ -1,0 +1,12 @@
+package com.idukbaduk.itseats.store.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class StoreListResponse {
+    private List<StoreDto> stores;
+}

--- a/src/main/java/com/idukbaduk/itseats/store/entity/StoreImage.java
+++ b/src/main/java/com/idukbaduk/itseats/store/entity/StoreImage.java
@@ -2,10 +2,16 @@ package com.idukbaduk.itseats.store.entity;
 
 import com.idukbaduk.itseats.global.BaseEntity;
 import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 @Table(name = "store_image")
 public class StoreImage extends BaseEntity {
 

--- a/src/main/java/com/idukbaduk/itseats/store/repository/StoreImageRepository.java
+++ b/src/main/java/com/idukbaduk/itseats/store/repository/StoreImageRepository.java
@@ -1,0 +1,16 @@
+package com.idukbaduk.itseats.store.repository;
+
+import com.idukbaduk.itseats.store.entity.StoreImage;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface StoreImageRepository extends JpaRepository<StoreImage, Long> {
+    @Query("SELECT si FROM StoreImage si " +
+            "WHERE si.store.storeId IN :storeIds " +
+            "ORDER BY si.store.storeId ASC, si.displayOrder ASC")
+    List<StoreImage> findImagesByStoreIds(@Param("storeIds") List<Long> storeIds);
+
+}

--- a/src/main/java/com/idukbaduk/itseats/store/repository/StoreRepository.java
+++ b/src/main/java/com/idukbaduk/itseats/store/repository/StoreRepository.java
@@ -5,10 +5,13 @@ import com.idukbaduk.itseats.store.entity.Store;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
 public interface StoreRepository extends JpaRepository<Store, Long> {
 
     Optional<Store> findByMemberAndStoreId(Member member, Long storeId);
+
+    List<Store> findAllByDeletedFalse();
 }

--- a/src/main/java/com/idukbaduk/itseats/store/service/StoreService.java
+++ b/src/main/java/com/idukbaduk/itseats/store/service/StoreService.java
@@ -1,21 +1,79 @@
 package com.idukbaduk.itseats.store.service;
 
 import com.idukbaduk.itseats.member.entity.Member;
+import com.idukbaduk.itseats.review.repository.ReviewRepository;
+import com.idukbaduk.itseats.store.dto.StoreDto;
+import com.idukbaduk.itseats.store.dto.StoreListResponse;
 import com.idukbaduk.itseats.store.entity.Store;
+import com.idukbaduk.itseats.store.entity.StoreImage;
 import com.idukbaduk.itseats.store.error.StoreException;
 import com.idukbaduk.itseats.store.error.enums.StoreErrorCode;
+import com.idukbaduk.itseats.store.repository.StoreImageRepository;
 import com.idukbaduk.itseats.store.repository.StoreRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 @Service
 @RequiredArgsConstructor
 public class StoreService {
 
     private final StoreRepository storeRepository;
+    private final StoreImageRepository storeImageRepository;
+    private final ReviewRepository reviewRepository;
 
     public Store getStore(Member member, Long storeId) {
         return storeRepository.findByMemberAndStoreId(member, storeId)
                 .orElseThrow(() -> new StoreException(StoreErrorCode.STORE_NOT_FOUND));
+    }
+
+    @Transactional(readOnly = true)
+    public StoreListResponse getAllStores() {
+
+        List<Store> stores = storeRepository.findAllByDeletedFalse();
+
+        if (stores.isEmpty()) {
+            throw new StoreException(StoreErrorCode.STORE_NOT_FOUND);
+        }
+
+        List<Long> storeIds = stores.stream().map(Store::getStoreId).toList();
+
+        List<StoreImage> images = storeImageRepository.findImagesByStoreIds(storeIds);
+
+        Map<Long, String> storeIdToImageUrl = new HashMap<>();
+        for (StoreImage image : images) {
+            Long storeId = image.getStore().getStoreId();
+            if (!storeIdToImageUrl.containsKey(storeId)) {
+                storeIdToImageUrl.put(storeId, image.getImageUrl());
+            }
+        }
+
+        List<Object[]> stats = reviewRepository.findReviewStatsByStoreIds(storeIds);
+        Map<Long, Double> storeIdToAvg = new HashMap<>();
+        Map<Long, Integer> storeIdToCount = new HashMap<>();
+        for (Object[] row : stats) {
+            Long storeId = (Long) row[0];
+            Double avg = row[1] != null ? Math.round(((Double) row[1]) * 10) / 10.0 : 0.0;
+            Long count = (Long) row[2];
+            storeIdToAvg.put(storeId, avg);
+            storeIdToCount.put(storeId, count.intValue());
+        }
+
+        List<StoreDto> storeDtos = stores.stream()
+                .map(store -> StoreDto.builder()
+                        .imageUrl(storeIdToImageUrl.get(store.getStoreId()))
+                        .name(store.getStoreName())
+                        .review(storeIdToAvg.getOrDefault(store.getStoreId(), 0.0))
+                        .reviewCount(storeIdToCount.getOrDefault(store.getStoreId(), 0))
+                        .build())
+                .toList();
+
+        return StoreListResponse.builder()
+                .stores(storeDtos)
+                .build();
     }
 }

--- a/src/main/java/com/idukbaduk/itseats/store/service/StoreService.java
+++ b/src/main/java/com/idukbaduk/itseats/store/service/StoreService.java
@@ -36,10 +36,6 @@ public class StoreService {
 
         List<Store> stores = storeRepository.findAllByDeletedFalse();
 
-        if (stores.isEmpty()) {
-            throw new StoreException(StoreErrorCode.STORE_NOT_FOUND);
-        }
-
         List<Long> storeIds = stores.stream().map(Store::getStoreId).toList();
 
         List<StoreImage> images = storeImageRepository.findImagesByStoreIds(storeIds);

--- a/src/test/java/com/idukbaduk/itseats/store/service/StoreServiceTest.java
+++ b/src/test/java/com/idukbaduk/itseats/store/service/StoreServiceTest.java
@@ -128,18 +128,6 @@ class StoreServiceTest {
     }
 
     @Test
-    @DisplayName("가게가 없을 때 전체 조회 예외 발생")
-    void getAllStores_emptyList_throwsException() {
-        // given
-        when(storeRepository.findAllByDeletedFalse()).thenReturn(Collections.emptyList());
-
-        // when & then
-        assertThatThrownBy(() -> storeService.getAllStores())
-                .isInstanceOf(StoreException.class)
-                .hasMessageContaining(StoreErrorCode.STORE_NOT_FOUND.getMessage());
-    }
-
-    @Test
     @DisplayName("리뷰가 없는 가게도 정상 처리")
     void getAllStores_noReviews_success() {
         // given

--- a/src/test/java/com/idukbaduk/itseats/store/service/StoreServiceTest.java
+++ b/src/test/java/com/idukbaduk/itseats/store/service/StoreServiceTest.java
@@ -163,4 +163,18 @@ class StoreServiceTest {
         assertThat(dto.getReview()).isEqualTo(0.0);
         assertThat(dto.getReviewCount()).isEqualTo(0);
     }
+
+    @Test
+    @DisplayName("가게가 없을 때 빈 리스트 반환")
+    void getAllStores_emptyList_returnsEmptyList() {
+        // given
+        when(storeRepository.findAllByDeletedFalse()).thenReturn(Collections.emptyList());
+
+        // when
+        StoreListResponse response = storeService.getAllStores();
+
+        // then
+        assertThat(response).isNotNull();
+        assertThat(response.getStores()).isEmpty(); // 빈 배열 확인
+    }
 }

--- a/src/test/java/com/idukbaduk/itseats/store/service/StoreServiceTest.java
+++ b/src/test/java/com/idukbaduk/itseats/store/service/StoreServiceTest.java
@@ -1,9 +1,14 @@
 package com.idukbaduk.itseats.store.service;
 
 import com.idukbaduk.itseats.member.entity.Member;
+import com.idukbaduk.itseats.review.repository.ReviewRepository;
+import com.idukbaduk.itseats.store.dto.StoreDto;
+import com.idukbaduk.itseats.store.dto.StoreListResponse;
 import com.idukbaduk.itseats.store.entity.Store;
+import com.idukbaduk.itseats.store.entity.StoreImage;
 import com.idukbaduk.itseats.store.error.StoreException;
 import com.idukbaduk.itseats.store.error.enums.StoreErrorCode;
+import com.idukbaduk.itseats.store.repository.StoreImageRepository;
 import com.idukbaduk.itseats.store.repository.StoreRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -12,17 +17,25 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class StoreServiceTest {
 
     @Mock
     private StoreRepository storeRepository;
+
+    @Mock
+    private StoreImageRepository storeImageRepository;
+
+    @Mock
+    private ReviewRepository reviewRepository;
 
     @InjectMocks
     private StoreService storeService;
@@ -63,5 +76,91 @@ class StoreServiceTest {
         assertThatThrownBy(() -> storeService.getStore(mockMember, storeId))
                 .isInstanceOf(StoreException.class)
                 .hasMessageContaining(StoreErrorCode.STORE_NOT_FOUND.getMessage());
+    }
+
+    @Test
+    @DisplayName("전체 가게 목록 조회 성공")
+    void getAllStores_success() {
+        // given
+        Store store1 = Store.builder().storeId(1L).storeName("버커킹 구름점").build();
+        Store store2 = Store.builder().storeId(2L).storeName("맥도날드 구름점").build();
+        Store store3 = Store.builder().storeId(3L).storeName("롯데리아 구름점").build();
+
+        StoreImage image1 = StoreImage.builder().store(store1).imageUrl("s3 url 1").build();
+        StoreImage image2 = StoreImage.builder().store(store2).imageUrl("s3 url 2").build();
+        StoreImage image3 = StoreImage.builder().store(store3).imageUrl("s3 url 3").build();
+
+        when(storeRepository.findAllByDeletedFalse())
+                .thenReturn(List.of(store1, store2, store3));
+        when(storeImageRepository.findImagesByStoreIds(List.of(1L, 2L, 3L)))
+                .thenReturn(List.of(image1, image2, image3));
+        when(reviewRepository.findReviewStatsByStoreIds(List.of(1L, 2L, 3L)))
+                .thenReturn(List.of(
+                        new Object[]{1L, 4.9, 1742L},
+                        new Object[]{2L, 4.7, 2847L},
+                        new Object[]{3L, 4.5, 3715L}
+                ));
+
+        // when
+        StoreListResponse response = storeService.getAllStores();
+
+        // then
+        assertThat(response).isNotNull();
+        assertThat(response.getStores()).hasSize(3);
+
+        StoreDto dto1 = response.getStores().get(0);
+        assertThat(dto1.getImageUrl()).isEqualTo("s3 url 1");
+        assertThat(dto1.getName()).isEqualTo("버커킹 구름점");
+        assertThat(dto1.getReview()).isEqualTo(4.9);
+        assertThat(dto1.getReviewCount()).isEqualTo(1742);
+
+        StoreDto dto2 = response.getStores().get(1);
+        assertThat(dto2.getImageUrl()).isEqualTo("s3 url 2");
+        assertThat(dto2.getName()).isEqualTo("맥도날드 구름점");
+        assertThat(dto2.getReview()).isEqualTo(4.7);
+        assertThat(dto2.getReviewCount()).isEqualTo(2847);
+
+        StoreDto dto3 = response.getStores().get(2);
+        assertThat(dto3.getImageUrl()).isEqualTo("s3 url 3");
+        assertThat(dto3.getName()).isEqualTo("롯데리아 구름점");
+        assertThat(dto3.getReview()).isEqualTo(4.5);
+        assertThat(dto3.getReviewCount()).isEqualTo(3715);
+    }
+
+    @Test
+    @DisplayName("가게가 없을 때 전체 조회 예외 발생")
+    void getAllStores_emptyList_throwsException() {
+        // given
+        when(storeRepository.findAllByDeletedFalse()).thenReturn(Collections.emptyList());
+
+        // when & then
+        assertThatThrownBy(() -> storeService.getAllStores())
+                .isInstanceOf(StoreException.class)
+                .hasMessageContaining(StoreErrorCode.STORE_NOT_FOUND.getMessage());
+    }
+
+    @Test
+    @DisplayName("리뷰가 없는 가게도 정상 처리")
+    void getAllStores_noReviews_success() {
+        // given
+        Store store1 = Store.builder().storeId(1L).storeName("신규 가게").build();
+        StoreImage image1 = StoreImage.builder().store(store1).imageUrl("s3 url").build();
+
+        when(storeRepository.findAllByDeletedFalse()).thenReturn(List.of(store1));
+        when(storeImageRepository.findImagesByStoreIds(List.of(1L))).thenReturn(List.of(image1));
+        when(reviewRepository.findReviewStatsByStoreIds(List.of(1L))).thenReturn(Collections.emptyList());
+
+        // when
+        StoreListResponse response = storeService.getAllStores();
+
+        // then
+        assertThat(response).isNotNull();
+        assertThat(response.getStores()).hasSize(1);
+
+        StoreDto dto = response.getStores().get(0);
+        assertThat(dto.getImageUrl()).isEqualTo("s3 url");
+        assertThat(dto.getName()).isEqualTo("신규 가게");
+        assertThat(dto.getReview()).isEqualTo(0.0);
+        assertThat(dto.getReviewCount()).isEqualTo(0);
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

#61 

## 📝작업 내용

- [ ] Dto - `StoreDto` , `StoreListResponse` 작성
- [ ] `StoreService`에 전체가게 조회 메서드 추가
- [ ] `StoreController` 추가
- [ ] `ReviewRepository`에 가게평점, 리뷰 수를 구하기 위한 쿼리 작성
- [ ] 테스트 코드 작성 후 작동 완료 확인
### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
	- 전체 매장 목록을 조회하는 API가 추가되었습니다. 매장명, 대표 이미지, 평균 평점, 리뷰 수를 함께 확인할 수 있습니다.
- **버그 수정**
	- 삭제된 매장이 목록에 포함되지 않도록 개선되었습니다.
- **테스트**
	- 매장 목록 조회 기능에 대한 다양한 테스트가 추가되어 신뢰성이 향상되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->