### PR TITLE
[Feature] 카테고리 별 가게 목록 조회 API 구현

### DIFF
--- a/src/main/java/com/idukbaduk/itseats/memberaddress/dto/enums/AddressResponse.java
+++ b/src/main/java/com/idukbaduk/itseats/memberaddress/dto/enums/AddressResponse.java
@@ -8,7 +8,7 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum AddressResponse implements Response {
 
-    CREATE_ADDRESS_SUCCESS(HttpStatus.CREATED, "주소 추가 성공");
+    ADDRESS_CREATE_SUCCESS(HttpStatus.CREATED, "주소 추가 성공");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/idukbaduk/itseats/store/controller/StoreController.java
+++ b/src/main/java/com/idukbaduk/itseats/store/controller/StoreController.java
@@ -1,12 +1,14 @@
 package com.idukbaduk.itseats.store.controller;
 
 import com.idukbaduk.itseats.global.response.BaseResponse;
+import com.idukbaduk.itseats.store.dto.StoreCategoryListResponse;
 import com.idukbaduk.itseats.store.dto.StoreListResponse;
 import com.idukbaduk.itseats.store.service.StoreService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -21,5 +23,11 @@ public class StoreController {
     public ResponseEntity<BaseResponse> getAllStores() {
         StoreListResponse response = storeService.getAllStores();
         return BaseResponse.toResponseEntity(HttpStatus.OK, "전체 가게 목록 조회 성공", response);
+    }
+
+    @GetMapping("/list/{storeCategory}")
+    public ResponseEntity<BaseResponse> getStoresByCategory(@PathVariable String storeCategory) {
+        StoreCategoryListResponse response = storeService.getStoresByCategory(storeCategory);
+        return BaseResponse.toResponseEntity(HttpStatus.OK, "카테고리 별 가게 목록 조회 성공", response);
     }
 }

--- a/src/main/java/com/idukbaduk/itseats/store/dto/StoreCategoryListResponse.java
+++ b/src/main/java/com/idukbaduk/itseats/store/dto/StoreCategoryListResponse.java
@@ -1,0 +1,14 @@
+package com.idukbaduk.itseats.store.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class StoreCategoryListResponse {
+    private String category;
+    private String categoryName;
+    private List<StoreDto> stores;
+}

--- a/src/main/java/com/idukbaduk/itseats/store/entity/StoreCategory.java
+++ b/src/main/java/com/idukbaduk/itseats/store/entity/StoreCategory.java
@@ -2,10 +2,16 @@ package com.idukbaduk.itseats.store.entity;
 
 import com.idukbaduk.itseats.global.BaseEntity;
 import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 @Table(name = "store_category")
 public class StoreCategory extends BaseEntity {
 
@@ -16,4 +22,7 @@ public class StoreCategory extends BaseEntity {
 
     @Column(name = "category_name", nullable = false)
     private String categoryName;
+
+    @Column(name = "category_cdoe", nullable = false)
+    private String categoryCode;
 }

--- a/src/main/java/com/idukbaduk/itseats/store/error/enums/StoreErrorCode.java
+++ b/src/main/java/com/idukbaduk/itseats/store/error/enums/StoreErrorCode.java
@@ -7,7 +7,9 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum StoreErrorCode implements ErrorCode {
 
-    STORE_NOT_FOUND(HttpStatus.NOT_FOUND, "가맹점 조회 실패");
+    STORE_NOT_FOUND(HttpStatus.NOT_FOUND, "가맹점 조회 실패"),
+    CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "카테고리 조회 실패"),
+    ;
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/idukbaduk/itseats/store/repository/StoreCategoryRepository.java
+++ b/src/main/java/com/idukbaduk/itseats/store/repository/StoreCategoryRepository.java
@@ -1,0 +1,10 @@
+package com.idukbaduk.itseats.store.repository;
+
+import com.idukbaduk.itseats.store.entity.StoreCategory;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface StoreCategoryRepository extends JpaRepository<StoreCategory, Long> {
+    Optional<StoreCategory> findByCategoryCode(String categoryCode);
+}

--- a/src/main/java/com/idukbaduk/itseats/store/repository/StoreRepository.java
+++ b/src/main/java/com/idukbaduk/itseats/store/repository/StoreRepository.java
@@ -14,4 +14,6 @@ public interface StoreRepository extends JpaRepository<Store, Long> {
     Optional<Store> findByMemberAndStoreId(Member member, Long storeId);
 
     List<Store> findAllByDeletedFalse();
+
+    List<Store> findAllByStoreCategory_CategoryCodeAndDeletedFalse(String categoryCode);
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

#63 

## 📝작업 내용

- [ ] Dto - `StoreCategoryListResponse` 작성
- [ ] StoreService - 카테고리 별 가게 목록 조회 관련 메서드 구현
- [ ] StoreController 작성
- [ ] 테스트 코드 작성 후 작동 확인 완료

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
