### PR TITLE
[Fix] 순환 참조 문제 해결 및 테스트 코드 수정

### DIFF
--- a/src/main/java/com/idukbaduk/itseats/memberaddress/service/MemberAddressService.java
+++ b/src/main/java/com/idukbaduk/itseats/memberaddress/service/MemberAddressService.java
@@ -1,7 +1,9 @@
 package com.idukbaduk.itseats.memberaddress.service;
 
 import com.idukbaduk.itseats.member.entity.Member;
-import com.idukbaduk.itseats.member.service.MemberService;
+import com.idukbaduk.itseats.member.error.MemberException;
+import com.idukbaduk.itseats.member.error.enums.MemberErrorCode;
+import com.idukbaduk.itseats.member.repository.MemberRepository;
 import com.idukbaduk.itseats.memberaddress.dto.AddressCreateRequest;
 import com.idukbaduk.itseats.memberaddress.dto.AddressCreateResponse;
 import com.idukbaduk.itseats.memberaddress.entity.MemberAddress;
@@ -19,11 +21,12 @@ import org.springframework.transaction.annotation.Transactional;
 public class MemberAddressService {
 
     private final MemberAddressRepository memberAddressRepository;
-    private final MemberService memberService;
+    private final MemberRepository memberRepository;
 
     @Transactional
     public AddressCreateResponse createAddress(String username, AddressCreateRequest addressCreateRequest) {
-        Member member = memberService.getMemberByUsername(username);
+        Member member = memberRepository.findByUsername(username)
+                .orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
 
         MemberAddress memberAddress = MemberAddress.builder()
                 .member(member)

--- a/src/test/java/com/idukbaduk/itseats/payment/service/PaymentServiceTest.java
+++ b/src/test/java/com/idukbaduk/itseats/payment/service/PaymentServiceTest.java
@@ -4,17 +4,15 @@ import com.idukbaduk.itseats.member.entity.Member;
 import com.idukbaduk.itseats.member.error.MemberException;
 import com.idukbaduk.itseats.member.error.enums.MemberErrorCode;
 import com.idukbaduk.itseats.member.repository.MemberRepository;
-import com.idukbaduk.itseats.member.service.MemberService;
 import com.idukbaduk.itseats.order.entity.Order;
-import com.idukbaduk.itseats.order.entity.enums.DeliveryType;
 import com.idukbaduk.itseats.order.error.OrderException;
 import com.idukbaduk.itseats.order.error.enums.OrderErrorCode;
 import com.idukbaduk.itseats.order.repository.OrderRepository;
-import com.idukbaduk.itseats.order.service.OrderService;
 import com.idukbaduk.itseats.payment.dto.PaymentCreateResponse;
 import com.idukbaduk.itseats.payment.dto.PaymentInfoRequest;
 import com.idukbaduk.itseats.payment.entity.Payment;
 import com.idukbaduk.itseats.payment.entity.enums.PaymentMethod;
+import com.idukbaduk.itseats.payment.entity.enums.PaymentStatus;
 import com.idukbaduk.itseats.payment.error.PaymentException;
 import com.idukbaduk.itseats.payment.error.enums.PaymentErrorCode;
 import com.idukbaduk.itseats.payment.repository.PaymentRepository;
@@ -29,7 +27,6 @@ import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -68,6 +65,7 @@ class PaymentServiceTest {
                 .orderId(1L)
                 .totalCost(10000)
                 .paymentMethod(PaymentMethod.COUPAY.name())
+                .paymentStatus(PaymentStatus.COMPLETED.name())
                 .storeRequest("맛있게 만들어주세요")
                 .riderRequest("문 앞에 두고 가주세요")
                 .build();
@@ -97,6 +95,7 @@ class PaymentServiceTest {
         assertThat(savedPayment.getOrder()).isEqualTo(order);
         assertThat(savedPayment.getTotalCost()).isEqualTo(paymentInfoRequest.getTotalCost());
         assertThat(savedPayment.getPaymentMethod()).isEqualTo(PaymentMethod.valueOf(paymentInfoRequest.getPaymentMethod()));
+        assertThat(savedPayment.getPaymentStatus()).isEqualTo(PaymentStatus.valueOf(paymentInfoRequest.getPaymentStatus()));
         assertThat(savedPayment.getStoreRequest()).isEqualTo(paymentInfoRequest.getStoreRequest());
         assertThat(savedPayment.getRiderRequest()).isEqualTo(paymentInfoRequest.getRiderRequest());
     }

--- a/src/test/java/com/idukbaduk/itseats/payment/service/PaymentServiceTest.java
+++ b/src/test/java/com/idukbaduk/itseats/payment/service/PaymentServiceTest.java
@@ -101,20 +101,6 @@ class PaymentServiceTest {
     }
 
     @Test
-    @DisplayName("존재하지 않는 멤버 조회시 예외 발생")
-    void createPayment_notExistMember() {
-        // given
-        when(memberRepository.findByUsername(username)).thenReturn(Optional.empty());
-
-        // when & then
-        assertThatThrownBy(() -> paymentService.createPayment(username, paymentInfoRequest))
-                .isInstanceOf(MemberException.class)
-                .hasMessageContaining(MemberErrorCode.MEMBER_NOT_FOUND.getMessage());
-
-        verify(memberRepository).findByUsername(username);
-    }
-
-    @Test
     @DisplayName("존재하지 않는 주문 조회시 예외 발생")
     void createPayment_notExistOrder() {
         // given

--- a/src/test/java/com/idukbaduk/itseats/payment/service/PaymentServiceTest.java
+++ b/src/test/java/com/idukbaduk/itseats/payment/service/PaymentServiceTest.java
@@ -102,6 +102,35 @@ class PaymentServiceTest {
     }
 
     @Test
+    @DisplayName("존재하지 않는 멤버 조회시 예외 발생")
+    void createPayment_notExistMember() {
+        // given
+        when(memberRepository.findByUsername(username)).thenReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> paymentService.createPayment(username, paymentInfoRequest))
+                .isInstanceOf(MemberException.class)
+                .hasMessageContaining(MemberErrorCode.MEMBER_NOT_FOUND.getMessage());
+
+        verify(memberRepository).findByUsername(username);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 주문 조회시 예외 발생")
+    void createPayment_notExistOrder() {
+        // given
+        when(memberRepository.findByUsername(username)).thenReturn(Optional.ofNullable(member));
+        when(orderRepository.findById(1L)).thenReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> paymentService.createPayment(username, paymentInfoRequest))
+                .isInstanceOf(OrderException.class)
+                .hasMessageContaining(OrderErrorCode.ORDER_NOT_FOUND.getMessage());
+
+        verify(orderRepository).findById(1L);
+    }
+
+    @Test
     @DisplayName("결제 정보를 성공적으로 반환")
     void getPaymentByOrder_success() {
         // given


### PR DESCRIPTION
## #️⃣연관된 이슈

#81

## 📝작업 내용

- `OrderService`와 `PaymentService`가 서로 참조하는 순환참조 문제가 발생하여 이를 수정했습니다.
> 문제 발생 스크린샷
> ![image](https://github.com/user-attachments/assets/d095b36b-bf2b-441a-be86-ff1835e69238)
---
- 순환 참조를 해결하기 위해 service 참조를 모두 repository 참조로 변경하였습니다.
   > 혹시 모를 예외를 대비하기 위해 이전에 만들어두었던 메서드는 삭제하지 않았습니다! 추후 리팩토링을 진행할 때 삭제하면 좋을 거 같습니다.

- 테스트 코드 수정
   - 코드 변경에 따른 테스트 코드를 수정하였습니다.
   - `setUp()` 메서드를 활용하여 테스트 코드를 수정하였습니다.

### 스크린샷

![image](https://github.com/user-attachments/assets/a7e1b0cc-ce08-4d67-9a93-c5b80016ab55)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **리팩터링**
    - 서비스 계층 의존성을 저장소(Repository) 의존성으로 변경하여 데이터 조회 및 예외 처리를 직접적으로 수행하도록 개선하였습니다.
    - 도메인별 예외 처리를 명확하게 하여, 엔티티가 존재하지 않을 경우 구체적인 예외 메시지를 제공합니다.

- **테스트**
    - 테스트 코드에서 서비스 모의 객체를 저장소 모의 객체로 교체하였습니다.
    - 공통 테스트 데이터를 `@BeforeEach`로 초기화하여 코드 중복을 줄였습니다.
    - 결제 생성 실패 등 예외 상황에 대한 테스트가 추가 및 명확화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->