### PR TITLE
[Feature] 가맹점 대시보드 조회(홈 화면) API 구현

### DIFF
--- a/src/main/java/com/idukbaduk/itseats/memberaddress/dto/enums/AddressResponse.java
+++ b/src/main/java/com/idukbaduk/itseats/memberaddress/dto/enums/AddressResponse.java
@@ -8,7 +8,7 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum AddressResponse implements Response {
 
-    ADDRESS_CREATE_SUCCESS(HttpStatus.CREATED, "주소 추가 성공");
+    CREATE_ADDRESS_SUCCESS(HttpStatus.CREATED, "주소 추가 성공");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/idukbaduk/itseats/order/entity/Order.java
+++ b/src/main/java/com/idukbaduk/itseats/order/entity/Order.java
@@ -78,4 +78,13 @@ public class Order extends BaseEntity {
 
     @Column(name = "store_location", nullable = false)
     private Point storeLocation;
+
+    @Column(name = "order_received_time", nullable = false)
+    private LocalDateTime orderReceivedTime;
+
+    @Column(name = "cook_start_time", nullable = false)
+    private LocalDateTime cookStartTime;
+
+    @Column(name = "order_end_time")
+    private LocalDateTime orderEndTime;
 }

--- a/src/main/java/com/idukbaduk/itseats/order/repository/OrderRepository.java
+++ b/src/main/java/com/idukbaduk/itseats/order/repository/OrderRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -37,4 +38,6 @@ public interface OrderRepository extends JpaRepository<Order, Long> {
     Long findAvgDeliveryTimeByType(@Param("deliveryType") String deliveryType);
 
     Optional<Order> findByMemberAndOrderId(Member member, Long orderId);
+
+    List<Order> findAllByStore_StoreId(Long storeStoreId);
 }

--- a/src/main/java/com/idukbaduk/itseats/order/repository/OrderRepository.java
+++ b/src/main/java/com/idukbaduk/itseats/order/repository/OrderRepository.java
@@ -61,7 +61,7 @@ public interface OrderRepository extends JpaRepository<Order, Long> {
     Long countAccurateOrdersByStoreId(@Param("storeId") Long storeId);
 
     @Query(value = """
-            SELECT AVG(TIMESTAMPDIFF(MINUTE, order_received_time, order_end_time)) " +
+            SELECT AVG(TIMESTAMPDIFF(MINUTE, order_received_time, order_end_time))
             FROM orders 
             WHERE store_id = :storeId 
             AND order_received_time IS NOT NULL 

--- a/src/main/java/com/idukbaduk/itseats/order/repository/OrderRepository.java
+++ b/src/main/java/com/idukbaduk/itseats/order/repository/OrderRepository.java
@@ -40,4 +40,44 @@ public interface OrderRepository extends JpaRepository<Order, Long> {
     Optional<Order> findByMemberAndOrderId(Member member, Long orderId);
 
     List<Order> findAllByStore_StoreId(Long storeStoreId);
+
+    @Query(value = """
+            SELECT AVG(TIMESTAMPDIFF(MINUTE, cook_start_time, order_end_time))
+            FROM orders
+            WHERE store_id = :storeId 
+            AND cook_start_time IS NOT NULL
+            AND order_end_time IS NOT NULL
+            """, nativeQuery = true)
+    Double findAverageCookTimeByStoreId(@Param("storeId") Long storeId);
+
+    @Query(value = """ 
+            SELECT COUNT(*)
+            FROM orders
+            WHERE store_id = :storeId 
+            AND order_end_time IS NOT NULL 
+            AND delivery_eta IS NOT NULL 
+            AND ABS(TIMESTAMPDIFF(MINUTE, delivery_eta, order_end_time)) <= 5
+            """, nativeQuery = true)
+    Long countAccurateOrdersByStoreId(@Param("storeId") Long storeId);
+
+    @Query(value = """
+            SELECT AVG(TIMESTAMPDIFF(MINUTE, order_received_time, order_end_time)) " +
+            FROM orders 
+            WHERE store_id = :storeId 
+            AND order_received_time IS NOT NULL 
+            AND order_end_time IS NOT NULL
+            """ , nativeQuery = true)
+    Double findAveragePickupTimeByStoreId(@Param("storeId") Long storeId);
+
+    @Query(value = "SELECT COUNT(*) FROM orders WHERE store_id = :storeId",
+            nativeQuery = true)
+    Long countTotalOrdersByStoreId(@Param("storeId") Long storeId);
+
+    @Query(value = """ 
+            SELECT COUNT(*) 
+            FROM orders WHERE store_id = :storeId AND order_status 
+            IN ('COOKING', 'RIDER_READY', 'DELIVERING', 'DELIVERED', 'COMPLETED')
+            """, nativeQuery = true)
+    Long countAcceptedOrdersByStoreId(@Param("storeId") Long storeId);
+
 }

--- a/src/main/java/com/idukbaduk/itseats/store/controller/OwnerStoreController.java
+++ b/src/main/java/com/idukbaduk/itseats/store/controller/OwnerStoreController.java
@@ -1,0 +1,26 @@
+package com.idukbaduk.itseats.store.controller;
+
+import com.idukbaduk.itseats.global.response.BaseResponse;
+import com.idukbaduk.itseats.store.dto.StoreDashboardResponse;
+import com.idukbaduk.itseats.store.service.OwnerStoreService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/owner")
+public class OwnerStoreController {
+
+    private final OwnerStoreService ownerStoreService;
+
+    @GetMapping("/{storeId}/dashboard")
+    public ResponseEntity<BaseResponse> getStoreDashboard(@PathVariable Long storeId) {
+        StoreDashboardResponse response = ownerStoreService.getDashboard(storeId);
+        return BaseResponse.toResponseEntity(HttpStatus.OK,"가맹점 대시보드 조회 성공", response);
+    }
+}

--- a/src/main/java/com/idukbaduk/itseats/store/dto/StoreDashboardResponse.java
+++ b/src/main/java/com/idukbaduk/itseats/store/dto/StoreDashboardResponse.java
@@ -1,0 +1,15 @@
+package com.idukbaduk.itseats.store.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class StoreDashboardResponse {
+    private String storeName;
+    private double customerRating;
+    private String avgCookTime;
+    private String cookTimeAccuracy;
+    private String pickupTime;
+    private String orderAcceptanceRate;
+}

--- a/src/main/java/com/idukbaduk/itseats/store/service/OwnerStoreService.java
+++ b/src/main/java/com/idukbaduk/itseats/store/service/OwnerStoreService.java
@@ -33,64 +33,25 @@ public class OwnerStoreService {
         Double avgRating = reviewRepository.findAverageRatingByStoreId(storeId);
         double customerRating = avgRating != null ? avgRating : 0.0;
 
-        List<Order> orders = orderRepository.findAllByStore_StoreId(storeId);
+        Double avgCookTime = orderRepository.findAverageCookTimeByStoreId(storeId);
+        Long accurateCount = orderRepository.countAccurateOrdersByStoreId(storeId);
+        Double avgPickupTime = orderRepository.findAveragePickupTimeByStoreId(storeId);
+        Long totalOrders = orderRepository.countTotalOrdersByStoreId(storeId);
+        Long acceptedOrders = orderRepository.countAcceptedOrdersByStoreId(storeId);
 
-        double avgCookTime = calculateAverageCookTime(orders);
-        double cookTimeAccuracy = calculateCookTimeAccuracy(orders);
-        double avgPickupTime = calculateAveragePickupTime(orders);
-        double acceptanceRate = calculateOrderAcceptanceRate(orders);
+        double cookTimeAccuracy = (totalOrders != null && totalOrders > 0 && accurateCount != null)
+                ? accurateCount * 100.0 / totalOrders : 0.0;
+
+        double acceptanceRate = (totalOrders != null && totalOrders > 0 && acceptedOrders != null)
+                ? acceptedOrders * 100.0 / totalOrders : 0.0;
 
         return StoreDashboardResponse.builder()
                 .storeName(store.getStoreName())
                 .customerRating(customerRating)
-                .avgCookTime((int) avgCookTime + "분")
+                .avgCookTime((avgCookTime != null ? avgCookTime.intValue() : 0) + "분")
                 .cookTimeAccuracy((int) cookTimeAccuracy + "%")
-                .pickupTime((int) avgPickupTime + "분")
+                .pickupTime((avgPickupTime != null ? avgPickupTime.intValue() : 0) + "분")
                 .orderAcceptanceRate((int) acceptanceRate + "%")
                 .build();
-    }
-
-    private double calculateAverageCookTime(List<Order> orders) {
-        return orders.stream()
-                .filter(o -> o.getCookStartTime() != null && o.getOrderEndTime() != null)
-                .mapToLong(o -> Duration.between(o.getCookStartTime(), o.getOrderEndTime()).toMinutes())
-                .average()
-                .orElse(0.0);
-    }
-
-    private double calculateCookTimeAccuracy(List<Order> orders) {
-        long total = orders.stream()
-                .filter(o -> o.getOrderEndTime() != null && o.getDeliveryEta() != null)
-                .count();
-
-        long accurate = orders.stream()
-                .filter(o -> o.getOrderEndTime() != null && o.getDeliveryEta() != null)
-                .filter(o -> {
-                    long diff = Math.abs(Duration.between(o.getDeliveryEta(), o.getOrderEndTime()).toMinutes());
-                    return diff <= 5;
-                })
-                .count();
-
-        return total == 0 ? 0.0 : accurate * 100.0 / total;
-    }
-
-    private double calculateAveragePickupTime(List<Order> orders) {
-        return orders.stream()
-                .filter(o -> o.getOrderReceivedTime() != null && o.getOrderEndTime() != null)
-                .mapToLong(o -> Duration.between(o.getOrderReceivedTime(), o.getOrderEndTime()).toMinutes())
-                .average()
-                .orElse(0.0);
-    }
-
-    private double calculateOrderAcceptanceRate(List<Order> orders) {
-        long total = orders.size();
-        long accepted = orders.stream()
-                .filter(o -> o.getOrderStatus() == OrderStatus.COOKING ||
-                        o.getOrderStatus() == OrderStatus.RIDER_READY ||
-                        o.getOrderStatus() == OrderStatus.DELIVERING ||
-                        o.getOrderStatus() == OrderStatus.DELIVERED ||
-                        o.getOrderStatus() == OrderStatus.COMPLETED)
-                .count();
-        return total == 0 ? 0.0 : accepted * 100.0 / total;
     }
 }

--- a/src/main/java/com/idukbaduk/itseats/store/service/OwnerStoreService.java
+++ b/src/main/java/com/idukbaduk/itseats/store/service/OwnerStoreService.java
@@ -1,0 +1,96 @@
+package com.idukbaduk.itseats.store.service;
+
+import com.idukbaduk.itseats.order.entity.Order;
+import com.idukbaduk.itseats.order.entity.enums.OrderStatus;
+import com.idukbaduk.itseats.order.repository.OrderRepository;
+import com.idukbaduk.itseats.review.repository.ReviewRepository;
+import com.idukbaduk.itseats.store.dto.StoreDashboardResponse;
+import com.idukbaduk.itseats.store.entity.Store;
+import com.idukbaduk.itseats.store.error.StoreException;
+import com.idukbaduk.itseats.store.error.enums.StoreErrorCode;
+import com.idukbaduk.itseats.store.repository.StoreRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Duration;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class OwnerStoreService {
+
+    private final StoreRepository storeRepository;
+    private final ReviewRepository reviewRepository;
+    private final OrderRepository orderRepository;
+
+    @Transactional(readOnly = true)
+    public StoreDashboardResponse getDashboard(Long storeId) {
+
+        Store store = storeRepository.findById(storeId)
+                .orElseThrow(() -> new StoreException(StoreErrorCode.STORE_NOT_FOUND));
+
+        Double avgRating = reviewRepository.findAverageRatingByStoreId(storeId);
+        double customerRating = avgRating != null ? avgRating : 0.0;
+
+        List<Order> orders = orderRepository.findAllByStore_StoreId(storeId);
+
+        double avgCookTime = calculateAverageCookTime(orders);
+        double cookTimeAccuracy = calculateCookTimeAccuracy(orders);
+        double avgPickupTime = calculateAveragePickupTime(orders);
+        double acceptanceRate = calculateOrderAcceptanceRate(orders);
+
+        return StoreDashboardResponse.builder()
+                .storeName(store.getStoreName())
+                .customerRating(customerRating)
+                .avgCookTime((int) avgCookTime + "분")
+                .cookTimeAccuracy((int) cookTimeAccuracy + "%")
+                .pickupTime((int) avgPickupTime + "분")
+                .orderAcceptanceRate((int) acceptanceRate + "%")
+                .build();
+    }
+
+    private double calculateAverageCookTime(List<Order> orders) {
+        return orders.stream()
+                .filter(o -> o.getCookStartTime() != null && o.getOrderEndTime() != null)
+                .mapToLong(o -> Duration.between(o.getCookStartTime(), o.getOrderEndTime()).toMinutes())
+                .average()
+                .orElse(0.0);
+    }
+
+    private double calculateCookTimeAccuracy(List<Order> orders) {
+        long total = orders.stream()
+                .filter(o -> o.getOrderEndTime() != null && o.getDeliveryEta() != null)
+                .count();
+
+        long accurate = orders.stream()
+                .filter(o -> o.getOrderEndTime() != null && o.getDeliveryEta() != null)
+                .filter(o -> {
+                    long diff = Math.abs(Duration.between(o.getDeliveryEta(), o.getOrderEndTime()).toMinutes());
+                    return diff <= 5;
+                })
+                .count();
+
+        return total == 0 ? 0.0 : accurate * 100.0 / total;
+    }
+
+    private double calculateAveragePickupTime(List<Order> orders) {
+        return orders.stream()
+                .filter(o -> o.getOrderReceivedTime() != null && o.getOrderEndTime() != null)
+                .mapToLong(o -> Duration.between(o.getOrderReceivedTime(), o.getOrderEndTime()).toMinutes())
+                .average()
+                .orElse(0.0);
+    }
+
+    private double calculateOrderAcceptanceRate(List<Order> orders) {
+        long total = orders.size();
+        long accepted = orders.stream()
+                .filter(o -> o.getOrderStatus() == OrderStatus.COOKING ||
+                        o.getOrderStatus() == OrderStatus.RIDER_READY ||
+                        o.getOrderStatus() == OrderStatus.DELIVERING ||
+                        o.getOrderStatus() == OrderStatus.DELIVERED ||
+                        o.getOrderStatus() == OrderStatus.COMPLETED)
+                .count();
+        return total == 0 ? 0.0 : accepted * 100.0 / total;
+    }
+}

--- a/src/main/java/com/idukbaduk/itseats/store/service/OwnerStoreService.java
+++ b/src/main/java/com/idukbaduk/itseats/store/service/OwnerStoreService.java
@@ -48,10 +48,11 @@ public class OwnerStoreService {
         return StoreDashboardResponse.builder()
                 .storeName(store.getStoreName())
                 .customerRating(customerRating)
-                .avgCookTime((avgCookTime != null ? avgCookTime.intValue() : 0) + "분")
-                .cookTimeAccuracy((int) cookTimeAccuracy + "%")
-                .pickupTime((avgPickupTime != null ? avgPickupTime.intValue() : 0) + "분")
-                .orderAcceptanceRate((int) acceptanceRate + "%")
+                .avgCookTime(Math.round(avgCookTime) + "분")
+                .cookTimeAccuracy(Math.round(cookTimeAccuracy) + "%")
+                .pickupTime(Math.round(avgPickupTime) + "분")
+                .orderAcceptanceRate(Math.round(acceptanceRate) + "%")
                 .build();
     }
+
 }

--- a/src/test/java/com/idukbaduk/itseats/store/controller/StoreDashboardControllerTest.java
+++ b/src/test/java/com/idukbaduk/itseats/store/controller/StoreDashboardControllerTest.java
@@ -1,0 +1,56 @@
+package com.idukbaduk.itseats.store.controller;
+
+import com.idukbaduk.itseats.store.dto.StoreDashboardResponse;
+import com.idukbaduk.itseats.store.error.StoreException;
+import com.idukbaduk.itseats.store.error.enums.StoreErrorCode;
+import com.idukbaduk.itseats.store.service.OwnerStoreService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(OwnerStoreController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class StoreDashboardControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private OwnerStoreService ownerStoreService;
+
+    @Test
+    @DisplayName("가게 대시보드 조회 성공")
+    void getStoreDashboard_success() throws Exception {
+        StoreDashboardResponse response = StoreDashboardResponse.builder()
+                .storeName("스타벅스")
+                .customerRating(4.2)
+                .avgCookTime("20분")
+                .cookTimeAccuracy("98%")
+                .pickupTime("43분")
+                .orderAcceptanceRate("100%")
+                .build();
+
+        when(ownerStoreService.getDashboard(1L)).thenReturn(response);
+
+        mockMvc.perform(get("/api/owner/1/dashboard")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.httpStatus").value(200))
+                .andExpect(jsonPath("$.message").value("가맹점 대시보드 조회 성공"))
+                .andExpect(jsonPath("$.data.storeName").value("스타벅스"))
+                .andExpect(jsonPath("$.data.customerRating").value(4.2))
+                .andExpect(jsonPath("$.data.avgCookTime").value("20분"))
+                .andExpect(jsonPath("$.data.cookTimeAccuracy").value("98%"))
+                .andExpect(jsonPath("$.data.pickupTime").value("43분"))
+                .andExpect(jsonPath("$.data.orderAcceptanceRate").value("100%"));
+    }
+}

--- a/src/test/java/com/idukbaduk/itseats/store/service/StoreDashboardServiceTest.java
+++ b/src/test/java/com/idukbaduk/itseats/store/service/StoreDashboardServiceTest.java
@@ -1,0 +1,105 @@
+package com.idukbaduk.itseats.store.service;
+
+import com.idukbaduk.itseats.order.entity.Order;
+import com.idukbaduk.itseats.order.entity.enums.OrderStatus;
+import com.idukbaduk.itseats.order.repository.OrderRepository;
+import com.idukbaduk.itseats.review.repository.ReviewRepository;
+import com.idukbaduk.itseats.store.dto.StoreDashboardResponse;
+import com.idukbaduk.itseats.store.entity.Store;
+import com.idukbaduk.itseats.store.error.StoreException;
+import com.idukbaduk.itseats.store.error.enums.StoreErrorCode;
+import com.idukbaduk.itseats.store.repository.StoreRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class StoreDashboardServiceTest {
+
+    @Mock StoreRepository storeRepository;
+    @Mock ReviewRepository reviewRepository;
+    @Mock OrderRepository orderRepository;
+
+    @InjectMocks
+    OwnerStoreService ownerStoreService;
+
+    @Test
+    @DisplayName("가게 대시보드 정상 조회")
+    void getDashboard_success() {
+        // given
+        Long storeId = 1L;
+        Store store = Store.builder().storeId(storeId).storeName("테스트가게").build();
+        when(storeRepository.findById(storeId)).thenReturn(Optional.of(store));
+        when(reviewRepository.findAverageRatingByStoreId(storeId)).thenReturn(4.5);
+
+        LocalDateTime now = LocalDateTime.now();
+        List<Order> orders = Arrays.asList(
+                Order.builder()
+                        .orderReceivedTime(now.minusMinutes(30))
+                        .cookStartTime(now.minusMinutes(28))
+                        .orderEndTime(now.minusMinutes(10))
+                        .deliveryEta(now.minusMinutes(12))
+                        .orderStatus(OrderStatus.COMPLETED)
+                        .build(),
+                Order.builder()
+                        .orderReceivedTime(now.minusMinutes(60))
+                        .cookStartTime(now.minusMinutes(58))
+                        .orderEndTime(now.minusMinutes(40))
+                        .deliveryEta(now.minusMinutes(41))
+                        .orderStatus(OrderStatus.COMPLETED)
+                        .build()
+        );
+        when(orderRepository.findAllByStore_StoreId(storeId)).thenReturn(orders);
+
+        // when
+        StoreDashboardResponse response = ownerStoreService.getDashboard(storeId);
+
+        // then
+        assertThat(response.getStoreName()).isEqualTo("테스트가게");
+        assertThat(response.getCustomerRating()).isEqualTo(4.5);
+        assertThat(response.getAvgCookTime()).endsWith("분");
+        assertThat(response.getCookTimeAccuracy()).endsWith("%");
+        assertThat(response.getPickupTime()).endsWith("분");
+        assertThat(response.getOrderAcceptanceRate()).endsWith("%");
+    }
+
+    @Test
+    @DisplayName("가게가 없으면 예외 발생")
+    void getDashboard_storeNotFound() {
+        Long storeId = 999L;
+        when(storeRepository.findById(storeId)).thenReturn(Optional.empty());
+        assertThatThrownBy(() -> ownerStoreService.getDashboard(storeId))
+                .isInstanceOf(StoreException.class)
+                .hasMessageContaining(StoreErrorCode.STORE_NOT_FOUND.getMessage());
+    }
+
+    @Test
+    @DisplayName("주문/리뷰가 없을 때도 정상 동작")
+    void getDashboard_emptyOrdersAndReviews() {
+        Long storeId = 2L;
+        Store store = Store.builder().storeId(storeId).storeName("빈가게").build();
+        when(storeRepository.findById(storeId)).thenReturn(Optional.of(store));
+        when(reviewRepository.findAverageRatingByStoreId(storeId)).thenReturn(null);
+        when(orderRepository.findAllByStore_StoreId(storeId)).thenReturn(Collections.emptyList());
+
+        StoreDashboardResponse response = ownerStoreService.getDashboard(storeId);
+
+        assertThat(response.getCustomerRating()).isEqualTo(0.0);
+        assertThat(response.getAvgCookTime()).isEqualTo("0분");
+        assertThat(response.getCookTimeAccuracy()).isEqualTo("0%");
+        assertThat(response.getPickupTime()).isEqualTo("0분");
+        assertThat(response.getOrderAcceptanceRate()).isEqualTo("0%");
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈
#77 

## 📝작업 내용

- [ ] `Order` 엔티티에 필드 추가 (`orderReceivedTime`, `cookStartTime` , `orderEndTime`)
- [ ] `StoreDashboardResponse` 작성
- [ ] `OwnerStoreService`에 `getStoreDashboard` 메서드 작성, 통계 자료 가져오는 메서드 추가
- [ ] `OwnerStoreController`에 대시 보드 조회 메서드 매핑
- [ ] `StoreDashboardServiceTest`, `StoreDashboardControllerTest` 테스트 코드 작성 후 작동 확인 완료

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
	- 가맹점주를 위한 대시보드 API가 추가되어, 매장별 주요 지표(매장명, 고객 평점, 평균 조리 시간, 조리 시간 정확도, 픽업 시간, 주문 수락률)를 한눈에 확인할 수 있습니다.
- **버그 수정**
	- 주소 응답 메시지의 명칭이 일관성 있게 변경되었습니다.
- **테스트**
	- 대시보드 API와 서비스의 정상 동작 및 예외 상황을 검증하는 테스트가 추가되었습니다.
- **기타**
	- 주문 정보에 주문 접수, 조리 시작, 주문 종료 시간 필드가 추가되어 주문 처리 과정을 더욱 상세히 추적할 수 있습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->