### PR TITLE
[Feature] 배달 수락 API 구현

### DIFF
--- a/src/main/java/com/idukbaduk/itseats/order/entity/Order.java
+++ b/src/main/java/com/idukbaduk/itseats/order/entity/Order.java
@@ -4,6 +4,8 @@ import com.idukbaduk.itseats.global.BaseEntity;
 import com.idukbaduk.itseats.member.entity.Member;
 import com.idukbaduk.itseats.order.entity.enums.OrderStatus;
 import com.idukbaduk.itseats.order.entity.enums.DeliveryType;
+import com.idukbaduk.itseats.order.error.OrderException;
+import com.idukbaduk.itseats.order.error.enums.OrderErrorCode;
 import com.idukbaduk.itseats.rider.entity.Rider;
 import com.idukbaduk.itseats.store.entity.Store;
 import jakarta.persistence.Column;
@@ -80,6 +82,13 @@ public class Order extends BaseEntity {
     private Point storeLocation;
 
     public void updateOrderStatusAccept(Rider rider, OrderStatus orderStatus) {
+        if (this.orderStatus != OrderStatus.COOKED) {
+            throw new OrderException(OrderErrorCode.ORDER_STATUS_UPDATE_FAIL);
+        }
+        if (this.rider != null) {
+            throw new OrderException(OrderErrorCode.ORDER_ALREADY_ASSIGNED);
+        }
+
         this.rider = rider;
         this.orderStatus = orderStatus;
     }

--- a/src/main/java/com/idukbaduk/itseats/order/entity/Order.java
+++ b/src/main/java/com/idukbaduk/itseats/order/entity/Order.java
@@ -47,7 +47,7 @@ public class Order extends BaseEntity {
     private Store store;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "rider_id", nullable = false)
+    @JoinColumn(name = "rider_id")
     private Rider rider;
 
     @Column(name = "order_number", nullable = false)
@@ -78,4 +78,9 @@ public class Order extends BaseEntity {
 
     @Column(name = "store_location", nullable = false)
     private Point storeLocation;
+
+    public void updateOrderStatusAccept(Rider rider, OrderStatus orderStatus) {
+        this.rider = rider;
+        this.orderStatus = orderStatus;
+    }
 }

--- a/src/main/java/com/idukbaduk/itseats/order/entity/enums/OrderStatus.java
+++ b/src/main/java/com/idukbaduk/itseats/order/entity/enums/OrderStatus.java
@@ -1,11 +1,21 @@
 package com.idukbaduk.itseats.order.entity.enums;
 
 public enum OrderStatus {
+
+    // 주문 취소
+    CANCELED,
+    // 주문 접수 중
     WAITING,
+    // 주문 조리 (주문 접수)
     COOKING,
+    // 조리 완료 (라이더 배차 시작)
+    COOKED,
+    // 배차 완료
     RIDER_READY,
+    // 배달 시작
     DELIVERING,
+    // 배달 완료
     DELIVERED,
-    COMPLETED,
-    CANCELED
+    // 주문 완료
+    COMPLETED
 }

--- a/src/main/java/com/idukbaduk/itseats/order/error/enums/OrderErrorCode.java
+++ b/src/main/java/com/idukbaduk/itseats/order/error/enums/OrderErrorCode.java
@@ -8,7 +8,9 @@ import org.springframework.http.HttpStatus;
 public enum OrderErrorCode implements ErrorCode {
 
     MENU_OPTION_SERIALIZATION_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "menuOption 직렬화 실패"),
-    ORDER_NOT_FOUND(HttpStatus.NOT_FOUND, "주문 조회 실패");
+    ORDER_NOT_FOUND(HttpStatus.NOT_FOUND, "주문 조회 실패"),
+    ORDER_STATUS_UPDATE_FAIL(HttpStatus.CONFLICT, "주문 상태 변경 실패"),
+    ORDER_ALREADY_ASSIGNED(HttpStatus.CONFLICT, "해당 주문은 이미 라이더가 배정되었습니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/idukbaduk/itseats/rider/controller/RiderController.java
+++ b/src/main/java/com/idukbaduk/itseats/rider/controller/RiderController.java
@@ -36,7 +36,7 @@ public class RiderController {
     public ResponseEntity<BaseResponse> updateDeliveryStatusAccept(
             @AuthenticationPrincipal UserDetails userDetails,
             @PathVariable("orderId") Long orderId) {
-        riderService.updateDeliveryStatusAccept(userDetails.getUsername(), orderId);
+        riderService.acceptDelivery(userDetails.getUsername(), orderId);
         return BaseResponse.toResponseEntity(RiderResponse.UPDATE_DELIVERY_STATUS_ACCEPT_SUCCESS);
     }
 }

--- a/src/main/java/com/idukbaduk/itseats/rider/controller/RiderController.java
+++ b/src/main/java/com/idukbaduk/itseats/rider/controller/RiderController.java
@@ -9,6 +9,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -29,5 +30,13 @@ public class RiderController {
                 RiderResponse.MODIFY_IS_WORKING_SUCCESS,
                 riderService.modifyWorking(userDetails.getUsername(), modifyWorkingRequest)
         );
+    }
+
+    @PostMapping("/{orderId}/accept")
+    public ResponseEntity<BaseResponse> updateDeliveryStatusAccept(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @PathVariable("orderId") Long orderId) {
+        riderService.updateDeliveryStatusAccept(userDetails.getUsername(), orderId);
+        return BaseResponse.toResponseEntity(RiderResponse.UPDATE_DELIVERY_STATUS_ACCEPT_SUCCESS);
     }
 }

--- a/src/main/java/com/idukbaduk/itseats/rider/dto/enums/RiderResponse.java
+++ b/src/main/java/com/idukbaduk/itseats/rider/dto/enums/RiderResponse.java
@@ -7,7 +7,8 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum RiderResponse implements Response {
 
-    MODIFY_IS_WORKING_SUCCESS(HttpStatus.OK, "출/퇴근 상태전환 성공");
+    MODIFY_IS_WORKING_SUCCESS(HttpStatus.OK, "출/퇴근 상태전환 성공"),
+    UPDATE_DELIVERY_STATUS_ACCEPT_SUCCESS(HttpStatus.OK, "배달 수락 완료");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/idukbaduk/itseats/rider/service/RiderService.java
+++ b/src/main/java/com/idukbaduk/itseats/rider/service/RiderService.java
@@ -43,7 +43,7 @@ public class RiderService {
     }
 
     @Transactional
-    public void updateDeliveryStatusAccept(String username, Long orderId) {
+    public void acceptDelivery(String username, Long orderId) {
         Member member = memberRepository.findByUsername(username)
                 .orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
         Rider rider = riderRepository.findByMember(member)

--- a/src/main/java/com/idukbaduk/itseats/rider/service/RiderService.java
+++ b/src/main/java/com/idukbaduk/itseats/rider/service/RiderService.java
@@ -4,6 +4,11 @@ import com.idukbaduk.itseats.member.entity.Member;
 import com.idukbaduk.itseats.member.error.MemberException;
 import com.idukbaduk.itseats.member.error.enums.MemberErrorCode;
 import com.idukbaduk.itseats.member.repository.MemberRepository;
+import com.idukbaduk.itseats.order.entity.Order;
+import com.idukbaduk.itseats.order.entity.enums.OrderStatus;
+import com.idukbaduk.itseats.order.error.OrderException;
+import com.idukbaduk.itseats.order.error.enums.OrderErrorCode;
+import com.idukbaduk.itseats.order.repository.OrderRepository;
 import com.idukbaduk.itseats.rider.dto.ModifyWorkingRequest;
 import com.idukbaduk.itseats.rider.dto.WorkingInfoResponse;
 import com.idukbaduk.itseats.rider.entity.Rider;
@@ -20,6 +25,7 @@ public class RiderService {
 
     private final RiderRepository riderRepository;
     private final MemberRepository memberRepository;
+    private final OrderRepository orderRepository;
 
     @Transactional
     public WorkingInfoResponse modifyWorking(String username, ModifyWorkingRequest modifyWorkingRequest) {
@@ -34,5 +40,18 @@ public class RiderService {
         return WorkingInfoResponse.builder()
                 .isWorking(rider.getIsWorking())
                 .build();
+    }
+
+    @Transactional
+    public void updateDeliveryStatusAccept(String username, Long orderId) {
+        Member member = memberRepository.findByUsername(username)
+                .orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
+        Rider rider = riderRepository.findByMember(member)
+                .orElseThrow(() -> new RiderException(RiderErrorCode.RIDER_NOT_FOUND));
+
+        Order order = orderRepository.findById(orderId)
+                .orElseThrow(() -> new OrderException(OrderErrorCode.ORDER_NOT_FOUND));
+
+        order.updateOrderStatusAccept(rider, OrderStatus.RIDER_READY);
     }
 }

--- a/src/test/java/com/idukbaduk/itseats/rider/controller/RiderControllerTest.java
+++ b/src/test/java/com/idukbaduk/itseats/rider/controller/RiderControllerTest.java
@@ -75,4 +75,21 @@ class RiderControllerTest {
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.message").value("출/퇴근 여부는 필수값입니다."));
     }
+
+    @Test
+    @DisplayName("배달 수락 성공")
+    @WithMockUser(username = "testuser")
+    void updateDeliveryStatusAccept_success() throws Exception {
+        // given
+        long orderId = 1L;
+
+        // when & then
+        mockMvc.perform(post("/api/rider/" + orderId + "/accept")
+                        .with(csrf()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.httpStatus")
+                        .value(RiderResponse.UPDATE_DELIVERY_STATUS_ACCEPT_SUCCESS.getHttpStatus().value()))
+                .andExpect(jsonPath("$.message")
+                        .value(RiderResponse.UPDATE_DELIVERY_STATUS_ACCEPT_SUCCESS.getMessage()));
+    }
 }

--- a/src/test/java/com/idukbaduk/itseats/rider/controller/RiderControllerTest.java
+++ b/src/test/java/com/idukbaduk/itseats/rider/controller/RiderControllerTest.java
@@ -1,7 +1,6 @@
 package com.idukbaduk.itseats.rider.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.idukbaduk.itseats.global.error.handler.GlobalErrorCode;
 import com.idukbaduk.itseats.rider.dto.ModifyWorkingRequest;
 import com.idukbaduk.itseats.rider.dto.WorkingInfoResponse;
 import com.idukbaduk.itseats.rider.dto.enums.RiderResponse;

--- a/src/test/java/com/idukbaduk/itseats/rider/service/RiderServiceTest.java
+++ b/src/test/java/com/idukbaduk/itseats/rider/service/RiderServiceTest.java
@@ -2,6 +2,9 @@ package com.idukbaduk.itseats.rider.service;
 
 import com.idukbaduk.itseats.member.entity.Member;
 import com.idukbaduk.itseats.member.repository.MemberRepository;
+import com.idukbaduk.itseats.order.entity.Order;
+import com.idukbaduk.itseats.order.entity.enums.OrderStatus;
+import com.idukbaduk.itseats.order.repository.OrderRepository;
 import com.idukbaduk.itseats.rider.dto.ModifyWorkingRequest;
 import com.idukbaduk.itseats.rider.dto.WorkingInfoResponse;
 import com.idukbaduk.itseats.rider.entity.Rider;
@@ -27,9 +30,10 @@ class RiderServiceTest {
 
     @Mock
     private RiderRepository riderRepository;
-
     @Mock
     private MemberRepository memberRepository;
+    @Mock
+    private OrderRepository orderRepository;
 
     @InjectMocks
     private RiderService riderService;
@@ -98,5 +102,26 @@ class RiderServiceTest {
         assertThatThrownBy(() -> riderService.modifyWorking(username, ModifyWorkingRequest.builder().build()))
                 .isInstanceOf(RiderException.class)
                 .hasMessageContaining(RiderErrorCode.RIDER_NOT_FOUND.getMessage());
+    }
+
+    @Test
+    @DisplayName("주문 상태를 배차 완료 상태로 변경에 성공")
+    void updateDeliveryStatusAccept_success() {
+        // given
+        Order order = Order.builder()
+                .orderId(1L)
+                .build();
+
+        when(memberRepository.findByUsername(username)).thenReturn(Optional.of(member));
+        when(riderRepository.findByMember(member)).thenReturn(Optional.of(rider));
+        when(orderRepository.findById(1L)).thenReturn(Optional.of(order));
+
+        // when
+        riderService.updateDeliveryStatusAccept(username, 1L);
+
+        // then
+        assertThat(order.getOrderId()).isEqualTo(1L);
+        assertThat(order.getRider()).isEqualTo(rider);
+        assertThat(order.getOrderStatus()).isEqualTo(OrderStatus.RIDER_READY);
     }
 }

--- a/src/test/java/com/idukbaduk/itseats/rider/service/RiderServiceTest.java
+++ b/src/test/java/com/idukbaduk/itseats/rider/service/RiderServiceTest.java
@@ -108,7 +108,7 @@ class RiderServiceTest {
 
     @Test
     @DisplayName("주문 상태를 배차 완료 상태로 변경에 성공")
-    void updateDeliveryStatusAccept_success() {
+    void acceptDelivery_success() {
         // given
         Order order = Order.builder()
                 .orderId(1L)
@@ -120,7 +120,7 @@ class RiderServiceTest {
         when(orderRepository.findById(1L)).thenReturn(Optional.of(order));
 
         // when
-        riderService.updateDeliveryStatusAccept(username, 1L);
+        riderService.acceptDelivery(username, 1L);
 
         // then
         assertThat(order.getOrderId()).isEqualTo(1L);
@@ -130,7 +130,7 @@ class RiderServiceTest {
 
     @Test
     @DisplayName("주문이 직전 단계가 아닌 경우 주문 상태를 변경하면 예외 발생")
-    void updateDeliveryStatusAccept_updateStatusFail() {
+    void acceptDelivery_acceptStatusFail() {
         // given
         Order order = Order.builder()
                 .orderId(1L)
@@ -142,14 +142,14 @@ class RiderServiceTest {
         when(orderRepository.findById(1L)).thenReturn(Optional.of(order));
 
         // when
-        assertThatThrownBy(() -> riderService.updateDeliveryStatusAccept(username, 1L))
+        assertThatThrownBy(() -> riderService.acceptDelivery(username, 1L))
                 .isInstanceOf(OrderException.class)
                 .hasMessageContaining(OrderErrorCode.ORDER_STATUS_UPDATE_FAIL.getMessage());
     }
 
     @Test
     @DisplayName("라이더가 이미 배차된 주문의 주문 상태를 변경하면 예외 발생")
-    void updateDeliveryStatusAccept_alreadyAssignedRider() {
+    void acceptDelivery_alreadyAssignedRider() {
         // given
         Order order = Order.builder()
                 .orderId(1L)
@@ -162,7 +162,7 @@ class RiderServiceTest {
         when(orderRepository.findById(1L)).thenReturn(Optional.of(order));
 
         // when
-        assertThatThrownBy(() -> riderService.updateDeliveryStatusAccept(username, 1L))
+        assertThatThrownBy(() -> riderService.acceptDelivery(username, 1L))
                 .isInstanceOf(OrderException.class)
                 .hasMessageContaining(OrderErrorCode.ORDER_ALREADY_ASSIGNED.getMessage());
     }


### PR DESCRIPTION
## #️⃣연관된 이슈

#78 

## 📝작업 내용

- 주문 ID의 주문의 배달 상태를 배달 수락으로 변경하고, 라이더 정보를 추가합니다.
---
- [x] DTO `RiderResponse` 구현 완료
- [x] Service `RiderService` 구현 완료
- [x] Controller `RiderController` 구현 완료
- [x] Test `RiderControllerTest`, `RiderServiceTest` 구현 및 작동 확인 완료
---
### 주문 상태 `OrderStatus`
- 주문 상태를 추가하고, 주석처리를 하여 어떤 상태인지 구분하기 쉽게 주석처리해두었습니다.

필드명 | 상태 | 설명
--|--|--
CANCELED | 주문 취소 | 가게가 주문을 취소하는 경우
WAITING | 주문 접수 중 | 사용자가 주문을 시작한 후 가게가 주문 접수(조리 중) 상태로 바꾸기 전까지의 상태
COOKING | 주문 조리 | 가게가 주문을 접수하면 주문 조리 상태로 변경
COOKED | 조리 완료 | 가게가 조리를 완료한 후 라이더 배차를 진행하는 상태
RIDER_READY | 배차 완료 | 인근 라이더가 배달 수락을 하는 경우
DELIVERING | 배달 중 | 라이더가 픽업 후 사용자에게로 음식을 배달하는 상태
DELIVERED | 배달 완료 | 라이더가 사용자에게 음식을 전달한 상태
COMPLETED | 주문 완료 | 일정 시간이 지난 후 주문이 완료된 상태

### 스크린샷

![image](https://github.com/user-attachments/assets/743c644e-1d38-4290-9b14-5ead094dd731)

![image](https://github.com/user-attachments/assets/a77e7f1a-1db3-45dd-b2f4-9bc0cddc7f2d)

+ 추가 테스트
![image](https://github.com/user-attachments/assets/1954b869-14a3-4786-8b94-dfd70259f3c1)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **신규 기능**
  - 라이더가 주문을 수락할 수 있는 새로운 API 엔드포인트가 추가되었습니다.
  - 주문 상태에 'COOKED'(조리 완료) 등 새로운 단계가 추가되어 주문 진행 과정을 더 세분화하였습니다.
  - 배달 수락 성공 시 안내 메시지가 추가되었습니다.

- **버그 수정**
  - 주문과 라이더의 연관 관계가 선택적으로 변경되어, 라이더가 없는 주문도 허용됩니다.

- **테스트**
  - 배달 수락 기능에 대한 컨트롤러 및 서비스 테스트가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->