### PR TITLE
[Feature] 메뉴 그룹 목록 조회 API 구현

### DIFF
--- a/src/main/java/com/idukbaduk/itseats/menu/controller/MenuController.java
+++ b/src/main/java/com/idukbaduk/itseats/menu/controller/MenuController.java
@@ -9,7 +9,6 @@ import com.idukbaduk.itseats.menu.dto.enums.MenuResponse;
 import com.idukbaduk.itseats.menu.service.MenuGroupService;
 import com.idukbaduk.itseats.menu.service.MenuService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -37,5 +36,11 @@ public class MenuController {
     ) {
         MenuGroupResponse data = menuGroupService.saveMenuGroup(storeId, request);
         return BaseResponse.toResponseEntity(MenuResponse.SAVE_MENU_GROUP_SUCCESS, data);
+    }
+
+    @GetMapping("/{storeId}/menu-groups")
+    public ResponseEntity<BaseResponse> getMenuGroup(@PathVariable Long storeId) {
+        MenuGroupResponse data = menuGroupService.getMenuGroup(storeId);
+        return BaseResponse.toResponseEntity(MenuResponse.GET_MENU_GROUP_SUCCESS, data);
     }
 }

--- a/src/main/java/com/idukbaduk/itseats/menu/dto/MenuGroupDto.java
+++ b/src/main/java/com/idukbaduk/itseats/menu/dto/MenuGroupDto.java
@@ -13,4 +13,8 @@ public class MenuGroupDto {
     private String menuGroupName;
     private int menuGroupPriority;
     private boolean menuGroupIsActive;
+
+    public String getDisplayName() {
+        return menuGroupName + (menuGroupIsActive ? "" : " (비활성화)");
+    }
 }

--- a/src/main/java/com/idukbaduk/itseats/menu/dto/enums/MenuResponse.java
+++ b/src/main/java/com/idukbaduk/itseats/menu/dto/enums/MenuResponse.java
@@ -8,6 +8,7 @@ import org.springframework.http.HttpStatus;
 public enum MenuResponse implements Response {
 
     GET_MENU_LIST_SUCCESS(HttpStatus.OK, "메뉴 목록 조회 성공"),
+    GET_MENU_GROUP_SUCCESS(HttpStatus.OK, "메뉴 그룹 조회 성공"),
     SAVE_MENU_GROUP_SUCCESS(HttpStatus.OK, "메뉴 그룹 설정 성공");
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/idukbaduk/itseats/menu/service/MenuGroupService.java
+++ b/src/main/java/com/idukbaduk/itseats/menu/service/MenuGroupService.java
@@ -45,6 +45,10 @@ public class MenuGroupService {
         return createResponse(storeId);
     }
 
+    public MenuGroupResponse getMenuGroup(Long storeId) {
+        return createResponse(storeId);
+    }
+
     private void sortMenuGroupRequest(MenuGroupRequest request) {
         request.getMenuGroups().sort(Comparator.comparing(MenuGroupDto::getMenuGroupPriority));
     }

--- a/src/test/java/com/idukbaduk/itseats/menu/controller/MenuControllerTest.java
+++ b/src/test/java/com/idukbaduk/itseats/menu/controller/MenuControllerTest.java
@@ -26,6 +26,7 @@ import java.util.List;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -45,13 +46,37 @@ class MenuControllerTest {
     @MockitoBean
     private MenuGroupService menuGroupService;
 
+    @DisplayName("메뉴 그룹 조회 성공")
+    @Test
+    void getMenuGroup_success() throws Exception {
+        // given
+        Long storeId = 1L;
+        MenuGroupResponse response = MenuGroupResponse.builder()
+                .menuGroups(new ArrayList<>(List.of(
+                        createMenuGroupDto("음료", 1, true),
+                        createMenuGroupDto("샌드위치", 999, false)
+                )))
+                .build();
+        when(menuGroupService.getMenuGroup(storeId)).thenReturn(response);
+
+        // when & then
+        mockMvc.perform(get("/api/owner/" + storeId + "/menu-groups")
+                .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.httpStatus").value(200))
+                .andExpect(jsonPath("$.message").value(MenuResponse.GET_MENU_GROUP_SUCCESS.getMessage()))
+                .andExpect(jsonPath("$.data.menuGroups[0].displayName").value("음료"))
+                .andExpect(jsonPath("$.data.menuGroups[1].menuGroupName").value("샌드위치"))
+                .andExpect(jsonPath("$.data.menuGroups[1].displayName").value("샌드위치 (비활성화)"));
+    }
+
     @Test
     @DisplayName("메뉴 그룹 설정 성공")
     void saveMenuGroup_success() throws Exception {
         // given
         MenuGroupResponse response = MenuGroupResponse.builder()
                 .menuGroups(new ArrayList<>(List.of(
-                        createMenuGroupDto("음료", 1)
+                        createMenuGroupDto("음료", 1, true)
                 )))
                 .build();
         when(menuGroupService.saveMenuGroup(any(), any())).thenReturn(response);
@@ -59,7 +84,7 @@ class MenuControllerTest {
         Long storeId = 1L;
         MenuGroupRequest request = MenuGroupRequest.builder()
                 .menuGroups(new ArrayList<>(List.of(
-                        createMenuGroupDto("음료", 1)
+                        createMenuGroupDto("음료", 1, true)
                 )))
                 .build();
 
@@ -74,11 +99,11 @@ class MenuControllerTest {
                 .andExpect(jsonPath("$.data.menuGroups[0].menuGroupName").value("음료"));
     }
 
-    private MenuGroupDto createMenuGroupDto(String groupName, int priority) {
+    private MenuGroupDto createMenuGroupDto(String groupName, int priority, boolean isActive) {
         return MenuGroupDto.builder()
                 .menuGroupName(groupName)
                 .menuGroupPriority(priority)
-                .menuGroupIsActive(true)
+                .menuGroupIsActive(isActive)
                 .build();
     }
 }

--- a/src/test/java/com/idukbaduk/itseats/menu/service/MenuGroupServiceTest.java
+++ b/src/test/java/com/idukbaduk/itseats/menu/service/MenuGroupServiceTest.java
@@ -22,8 +22,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.*;
@@ -42,6 +41,29 @@ class MenuGroupServiceTest {
     private MenuGroupService menuGroupService;
 
     @Test
+    @DisplayName("메뉴 그룹을 조회한다")
+    void getMenuGroup_success() {
+        // given
+        Long storeId = 1L;
+        List<MenuGroup> menuGroups = List.of(
+                createMenuGroup(10L, "음료", 1, true),
+                createMenuGroup(20L, "베이커리", 999, false)
+        );
+        when(menuGroupRepository.findMenuGroupsByStoreId(storeId)).thenReturn(menuGroups);
+
+        // when
+        MenuGroupResponse data = menuGroupService.getMenuGroup(storeId);
+
+        // then
+        assertThat(data.getMenuGroups()).hasSize(2)
+                .extracting("menuGroupName", "menuGroupIsActive", "displayName")
+                .containsExactlyInAnyOrder(
+                        tuple("음료", true, "음료"),
+                        tuple("베이커리", false, "베이커리 (비활성화)")
+                );
+    }
+
+    @Test
     @DisplayName("메뉴 그룹을 설정한다")
     void saveMenuGroup_success() {
         // given
@@ -50,8 +72,8 @@ class MenuGroupServiceTest {
 
 
         List<MenuGroup> existingMenuGroups = List.of(
-                createMenuGroup(10L, "음료", 1, Collections.emptyList()),
-                createMenuGroup(20L, "베이커리", 2, Collections.emptyList())
+                createMenuGroup(10L, "음료", 1, true),
+                createMenuGroup(20L, "베이커리", 2, true)
         );
         when(menuGroupRepository.findMenuGroupsByStoreId(storeId)).thenReturn(existingMenuGroups);
 
@@ -79,8 +101,8 @@ class MenuGroupServiceTest {
         when(storeRepository.findById(storeId)).thenReturn(Optional.of(new Store()));
 
         List<MenuGroup> existingMenuGroups = List.of(
-                createMenuGroup(10L, "음료", 1, Collections.emptyList()),
-                createMenuGroup(20L, "베이커리", 2, Collections.emptyList())
+                createMenuGroup(10L, "음료", 1, true),
+                createMenuGroup(20L, "베이커리", 2, true)
         );
         when(menuGroupRepository.findMenuGroupsByStoreId(storeId)).thenReturn(existingMenuGroups);
 
@@ -136,13 +158,12 @@ class MenuGroupServiceTest {
                 .isInstanceOf(StoreException.class);
     }
 
-    private MenuGroup createMenuGroup(long groupId, String groupName, int priority, List<Menu> menus) {
+    private MenuGroup createMenuGroup(long groupId, String groupName, int priority, boolean isActive) {
         return MenuGroup.builder()
                 .menuGroupId(groupId)
                 .menuGroupName(groupName)
                 .menuGroupPriority(priority)
-                .menuGroupIsActive(true)
-                .menus(menus)
+                .menuGroupIsActive(isActive)
                 .build();
     }
 


### PR DESCRIPTION
## #️⃣연관된 이슈

#92 
closes #92

## 📝작업 내용

- [x] 조회를 위한 쿼리 확인 및 추가
- [x] 서비스 메서드 추가
- [x] 컨트롤러 메서드 추가
- [x] 서비스 및 컨트롤러 테스트코드 작성

`MenuGroupDto`에 `displayName` 필드를 추가함 -> 비활성화된 메뉴 그룹은 "메뉴 그룹명 (비활성화)" 표시

### 스크린샷 (선택)

<details>
    <summary>열기</summary>

![메뉴 그룹 조회](https://github.com/user-attachments/assets/230f0c7d-f11c-487a-aace-69037e3880b3)

</details>

## 💬리뷰 요구사항(선택)

메뉴 그룹 설정 로직을 조금 바꿔 조회 API 추가하였습니다. 또 프론트엔드에서 비활성화된 그룹은 그룹명 뒤에 "(비활성화)"를 붙여주면 좋을 거 같아 DTO에 `displayName` 필드를 추가하였습니다.

수정 필요한 부분이 있으면 코멘트 달아주세요!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
    - 매장별 메뉴 그룹 정보를 조회할 수 있는 GET 엔드포인트가 추가되었습니다.
    - 메뉴 그룹이 비활성화된 경우, 이름에 "(비활성화)"가 표시됩니다.

- **버그 수정**
    - 사용하지 않는 import가 제거되었습니다.

- **테스트**
    - 메뉴 그룹 조회 기능에 대한 테스트가 추가되었습니다.
    - 테스트 데이터 생성 시 메뉴 그룹 활성/비활성 상태를 지정할 수 있도록 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->