### PR TITLE
[Feature] 배달 완료 API 구현

### DIFF
--- a/src/main/java/com/idukbaduk/itseats/order/entity/Order.java
+++ b/src/main/java/com/idukbaduk/itseats/order/entity/Order.java
@@ -99,4 +99,9 @@ public class Order extends BaseEntity {
         this.rider = rider;
         this.orderStatus = orderStatus;
     }
+
+    public void updateStatus(OrderStatus orderStatus) {
+        orderStatus.validateTransitionFrom(this.orderStatus);
+        this.orderStatus = orderStatus;
+    }
 }

--- a/src/main/java/com/idukbaduk/itseats/order/entity/Order.java
+++ b/src/main/java/com/idukbaduk/itseats/order/entity/Order.java
@@ -91,12 +91,10 @@ public class Order extends BaseEntity {
     private LocalDateTime orderEndTime;
 
     public void updateOrderStatusAccept(Rider rider, OrderStatus orderStatus) {
-        if (this.orderStatus != OrderStatus.COOKED) {
-          throw new OrderException(OrderErrorCode.ORDER_STATUS_UPDATE_FAIL);
-        }
         if (this.rider != null) {
-          throw new OrderException(OrderErrorCode.ORDER_ALREADY_ASSIGNED);
+            throw new OrderException(OrderErrorCode.ORDER_ALREADY_ASSIGNED);
         }
+        orderStatus.validateTransitionFrom(this.orderStatus);
 
         this.rider = rider;
         this.orderStatus = orderStatus;

--- a/src/main/java/com/idukbaduk/itseats/order/entity/Order.java
+++ b/src/main/java/com/idukbaduk/itseats/order/entity/Order.java
@@ -91,14 +91,14 @@ public class Order extends BaseEntity {
     private LocalDateTime orderEndTime;
 
     public void updateOrderStatusAccept(Rider rider, OrderStatus orderStatus) {
-      if (this.orderStatus != OrderStatus.COOKED) {
+        if (this.orderStatus != OrderStatus.COOKED) {
           throw new OrderException(OrderErrorCode.ORDER_STATUS_UPDATE_FAIL);
-      }
-      if (this.rider != null) {
+        }
+        if (this.rider != null) {
           throw new OrderException(OrderErrorCode.ORDER_ALREADY_ASSIGNED);
-      }
+        }
 
-      this.rider = rider;
-      this.orderStatus = orderStatus;
+        this.rider = rider;
+        this.orderStatus = orderStatus;
     }
 }

--- a/src/main/java/com/idukbaduk/itseats/order/entity/enums/OrderStatus.java
+++ b/src/main/java/com/idukbaduk/itseats/order/entity/enums/OrderStatus.java
@@ -5,6 +5,8 @@ import com.idukbaduk.itseats.order.error.enums.OrderErrorCode;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
+import java.util.Objects;
+
 @Getter
 @RequiredArgsConstructor
 public enum OrderStatus {
@@ -29,7 +31,7 @@ public enum OrderStatus {
     private final OrderStatus previousStatus;
 
     public void validateTransitionFrom(OrderStatus currentStatus) {
-        if (this.previousStatus != currentStatus) {
+        if (!Objects.equals(this.previousStatus, currentStatus)) {
             throw new OrderException(OrderErrorCode.ORDER_STATUS_UPDATE_FAIL);
         }
     }

--- a/src/main/java/com/idukbaduk/itseats/order/entity/enums/OrderStatus.java
+++ b/src/main/java/com/idukbaduk/itseats/order/entity/enums/OrderStatus.java
@@ -1,21 +1,36 @@
 package com.idukbaduk.itseats.order.entity.enums;
 
+import com.idukbaduk.itseats.order.error.OrderException;
+import com.idukbaduk.itseats.order.error.enums.OrderErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
 public enum OrderStatus {
 
     // 주문 취소
-    CANCELED,
+    CANCELED(null),
     // 주문 접수 중
-    WAITING,
+    WAITING(null),
     // 주문 조리 (주문 접수)
-    COOKING,
+    COOKING(WAITING),
     // 조리 완료 (라이더 배차 시작)
-    COOKED,
+    COOKED(COOKING),
     // 배차 완료
-    RIDER_READY,
+    RIDER_READY(COOKED),
     // 배달 시작
-    DELIVERING,
+    DELIVERING(RIDER_READY),
     // 배달 완료
-    DELIVERED,
+    DELIVERED(DELIVERING),
     // 주문 완료
-    COMPLETED
+    COMPLETED(DELIVERED);
+
+    private final OrderStatus previousStatus;
+
+    public void validateTransitionFrom(OrderStatus currentStatus) {
+        if (this.previousStatus != currentStatus) {
+            throw new OrderException(OrderErrorCode.ORDER_STATUS_UPDATE_FAIL);
+        }
+    }
 }

--- a/src/main/java/com/idukbaduk/itseats/order/repository/OrderRepository.java
+++ b/src/main/java/com/idukbaduk/itseats/order/repository/OrderRepository.java
@@ -2,6 +2,7 @@ package com.idukbaduk.itseats.order.repository;
 
 import com.idukbaduk.itseats.member.entity.Member;
 import com.idukbaduk.itseats.order.entity.Order;
+import com.idukbaduk.itseats.rider.entity.Rider;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -80,4 +81,5 @@ public interface OrderRepository extends JpaRepository<Order, Long> {
             """, nativeQuery = true)
     Long countAcceptedOrdersByStoreId(@Param("storeId") Long storeId);
 
+    Optional<Order> findByRiderAndOrderId(Rider rider, Long orderId);
 }

--- a/src/main/java/com/idukbaduk/itseats/rider/controller/RiderController.java
+++ b/src/main/java/com/idukbaduk/itseats/rider/controller/RiderController.java
@@ -1,6 +1,7 @@
 package com.idukbaduk.itseats.rider.controller;
 
 import com.idukbaduk.itseats.global.response.BaseResponse;
+import com.idukbaduk.itseats.order.entity.enums.OrderStatus;
 import com.idukbaduk.itseats.rider.dto.ModifyWorkingRequest;
 import com.idukbaduk.itseats.rider.dto.enums.RiderResponse;
 import com.idukbaduk.itseats.rider.service.RiderService;
@@ -37,6 +38,14 @@ public class RiderController {
             @AuthenticationPrincipal UserDetails userDetails,
             @PathVariable("orderId") Long orderId) {
         riderService.acceptDelivery(userDetails.getUsername(), orderId);
-        return BaseResponse.toResponseEntity(RiderResponse.UPDATE_DELIVERY_STATUS_ACCEPT_SUCCESS);
+        return BaseResponse.toResponseEntity(RiderResponse.UPDATE_STATUS_ACCEPT_SUCCESS);
+    }
+
+    @PostMapping("/{orderId}/done")
+    public ResponseEntity<BaseResponse> updateDeliveryStatusDone(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @PathVariable("orderId") Long orderId) {
+        riderService.updateOrderStatusAfterAccept(userDetails.getUsername(), orderId, OrderStatus.DELIVERED);
+        return BaseResponse.toResponseEntity(RiderResponse.UPDATE_STATUS_DELIVERED_SUCCESS);
     }
 }

--- a/src/main/java/com/idukbaduk/itseats/rider/dto/enums/RiderResponse.java
+++ b/src/main/java/com/idukbaduk/itseats/rider/dto/enums/RiderResponse.java
@@ -8,7 +8,8 @@ import org.springframework.http.HttpStatus;
 public enum RiderResponse implements Response {
 
     MODIFY_IS_WORKING_SUCCESS(HttpStatus.OK, "출/퇴근 상태전환 성공"),
-    UPDATE_DELIVERY_STATUS_ACCEPT_SUCCESS(HttpStatus.OK, "배달 수락 완료");
+    UPDATE_STATUS_ACCEPT_SUCCESS(HttpStatus.OK, "배달 수락 완료 성공"),
+    UPDATE_STATUS_DELIVERED_SUCCESS(HttpStatus.OK, "배달 완료 성공" );
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/idukbaduk/itseats/rider/service/RiderService.java
+++ b/src/main/java/com/idukbaduk/itseats/rider/service/RiderService.java
@@ -54,4 +54,17 @@ public class RiderService {
 
         order.updateOrderStatusAccept(rider, OrderStatus.RIDER_READY);
     }
+
+    @Transactional
+    public void updateOrderStatusAfterAccept(String username, Long orderId, OrderStatus orderStatus) {
+        Member member = memberRepository.findByUsername(username)
+                .orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
+        Rider rider = riderRepository.findByMember(member)
+                .orElseThrow(() -> new RiderException(RiderErrorCode.RIDER_NOT_FOUND));
+
+        Order order = orderRepository.findByRiderAndOrderId(rider, orderId)
+                .orElseThrow(() -> new OrderException(OrderErrorCode.ORDER_NOT_FOUND));
+
+        order.updateStatus(orderStatus);
+    }
 }

--- a/src/test/java/com/idukbaduk/itseats/rider/controller/RiderControllerTest.java
+++ b/src/test/java/com/idukbaduk/itseats/rider/controller/RiderControllerTest.java
@@ -87,8 +87,25 @@ class RiderControllerTest {
                         .with(csrf()))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.httpStatus")
-                        .value(RiderResponse.UPDATE_DELIVERY_STATUS_ACCEPT_SUCCESS.getHttpStatus().value()))
+                        .value(RiderResponse.UPDATE_STATUS_ACCEPT_SUCCESS.getHttpStatus().value()))
                 .andExpect(jsonPath("$.message")
-                        .value(RiderResponse.UPDATE_DELIVERY_STATUS_ACCEPT_SUCCESS.getMessage()));
+                        .value(RiderResponse.UPDATE_STATUS_ACCEPT_SUCCESS.getMessage()));
+    }
+
+    @Test
+    @DisplayName("배달 완료 성공")
+    @WithMockUser(username = "testuser")
+    void updateDeliveryStatusDone_success() throws Exception {
+        // given
+        long orderId = 1L;
+
+        // when & then
+        mockMvc.perform(post("/api/rider/" + orderId + "/done")
+                        .with(csrf()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.httpStatus")
+                        .value(RiderResponse.UPDATE_STATUS_DELIVERED_SUCCESS.getHttpStatus().value()))
+                .andExpect(jsonPath("$.message")
+                        .value(RiderResponse.UPDATE_STATUS_DELIVERED_SUCCESS.getMessage()));
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

#79

## 📝작업 내용

- 현재 라이더가 배달 중인 주문 ID의 주문 배달 상태를 배달 완료로 변경합니다.
---
- [x] DTO `RiderResponse` 구현 완료
- [x] Service `RiderService` 구현 완료
- [x] Controller `RiderController` 구현 완료
- [x] Repository `OrderRepository` 로직 추가
- [x] Test `RiderControllerTest`, `RiderServiceTest` 구현 및 작동 확인 완료
---
- 주문 상태 enum `OrderStatus`에 이전 상태 지정 및 검증 로직 추가
- `Order` Entity에 주문 상태 업데이트 메서드 추가

### 스크린샷

![image](https://github.com/user-attachments/assets/e23a7ed7-babe-4e4b-a4b4-2bba2112ab7c)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 라이더가 주문을 배달 완료로 표시할 수 있는 새로운 엔드포인트가 추가되었습니다.
- **버그 수정**
  - 주문 상태 변경 시 유효한 상태 전환만 허용하도록 개선되었습니다.
- **테스트**
  - 배달 완료 처리 및 상태 변경에 대한 테스트가 추가되었습니다.
- **문서화**
  - 응답 메시지 및 상태 코드가 명확하게 반영되도록 일부 상수가 수정 및 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->