### PR TITLE
[Fix] MySQL POINT 자료형 사용을 위한 설정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,6 +46,7 @@ dependencies {
      * - MySQL
      */
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.hibernate.orm:hibernate-spatial:6.6.18.Final'
     implementation 'com.mysql:mysql-connector-j:8.3.0'
 
     /**

--- a/src/main/java/com/idukbaduk/itseats/global/util/GeoUtil.java
+++ b/src/main/java/com/idukbaduk/itseats/global/util/GeoUtil.java
@@ -3,9 +3,10 @@ package com.idukbaduk.itseats.global.util;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.GeometryFactory;
 import org.locationtech.jts.geom.Point;
+import org.locationtech.jts.geom.PrecisionModel;
 
 public class GeoUtil {
-    private static final GeometryFactory geometryFactory = new GeometryFactory();
+    private static final GeometryFactory geometryFactory = new GeometryFactory(new PrecisionModel(), 4326);
 
     /**
      * 경도/위도를 Point 객체로 변환한다.

--- a/src/main/java/com/idukbaduk/itseats/global/util/GeoUtil.java
+++ b/src/main/java/com/idukbaduk/itseats/global/util/GeoUtil.java
@@ -1,0 +1,19 @@
+package com.idukbaduk.itseats.global.util;
+
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.Point;
+
+public class GeoUtil {
+    private static final GeometryFactory geometryFactory = new GeometryFactory();
+
+    /**
+     * 경도/위도를 Point 객체로 변환한다.
+     * @param lng 경도
+     * @param lat 위도
+     * @return Point 객체
+     */
+    public static Point toPoint(double lng, double lat) {
+        return geometryFactory.createPoint(new Coordinate(lng, lat));
+    }
+}

--- a/src/main/java/com/idukbaduk/itseats/memberaddress/dto/AddressCreateRequest.java
+++ b/src/main/java/com/idukbaduk/itseats/memberaddress/dto/AddressCreateRequest.java
@@ -9,7 +9,7 @@ public class AddressCreateRequest {
 
     private String mainAddress;
     private String detailAddress;
-    private double locationX;
-    private double locationY;
+    private double lng;
+    private double lat;
     private String addressCategory;
 }

--- a/src/main/java/com/idukbaduk/itseats/memberaddress/entity/MemberAddress.java
+++ b/src/main/java/com/idukbaduk/itseats/memberaddress/entity/MemberAddress.java
@@ -8,7 +8,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.data.geo.Point;
+import org.locationtech.jts.geom.Point;
 
 import java.time.LocalDateTime;
 
@@ -35,7 +35,7 @@ public class MemberAddress extends BaseEntity {
     @Column(name = "detail_address", nullable = false)
     private String detailAddress;
 
-    @Column(name = "location", nullable = false)
+    @Column(name = "location", columnDefinition = "POINT", nullable = false)
     private Point location;
 
     @Enumerated(EnumType.STRING)

--- a/src/main/java/com/idukbaduk/itseats/memberaddress/service/MemberAddressService.java
+++ b/src/main/java/com/idukbaduk/itseats/memberaddress/service/MemberAddressService.java
@@ -1,5 +1,6 @@
 package com.idukbaduk.itseats.memberaddress.service;
 
+import com.idukbaduk.itseats.global.util.GeoUtil;
 import com.idukbaduk.itseats.member.entity.Member;
 import com.idukbaduk.itseats.member.error.MemberException;
 import com.idukbaduk.itseats.member.error.enums.MemberErrorCode;
@@ -12,7 +13,6 @@ import com.idukbaduk.itseats.memberaddress.error.MemberAddressException;
 import com.idukbaduk.itseats.memberaddress.error.enums.MemberAddressErrorCode;
 import com.idukbaduk.itseats.memberaddress.repository.MemberAddressRepository;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.geo.Point;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -32,7 +32,7 @@ public class MemberAddressService {
                 .member(member)
                 .mainAddress(addressCreateRequest.getMainAddress())
                 .detailAddress(addressCreateRequest.getDetailAddress())
-                .location(new Point(addressCreateRequest.getLocationX(), addressCreateRequest.getLocationY()))
+                .location(GeoUtil.toPoint(addressCreateRequest.getLng(), addressCreateRequest.getLat()))
                 .addressCategory(AddressCategory.valueOf(addressCreateRequest.getAddressCategory()))
                 .build();
         memberAddressRepository.save(memberAddress);

--- a/src/main/java/com/idukbaduk/itseats/order/entity/Order.java
+++ b/src/main/java/com/idukbaduk/itseats/order/entity/Order.java
@@ -24,7 +24,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import org.springframework.data.geo.Point;
+import org.locationtech.jts.geom.Point;
 import java.time.LocalDateTime;
 
 @Entity
@@ -75,10 +75,10 @@ public class Order extends BaseEntity {
     @Column(name = "delivery_address", nullable = false)
     private String deliveryAddress;
 
-    @Column(name = "destination_location", nullable = false)
+    @Column(name = "destination_location", columnDefinition = "POINT", nullable = false)
     private Point destinationLocation;
 
-    @Column(name = "store_location", nullable = false)
+    @Column(name = "store_location", columnDefinition = "POINT", nullable = false)
     private Point storeLocation;
 
     @Column(name = "order_received_time", nullable = false)

--- a/src/main/java/com/idukbaduk/itseats/rider/entity/Rider.java
+++ b/src/main/java/com/idukbaduk/itseats/rider/entity/Rider.java
@@ -9,7 +9,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.data.geo.Point;
+import org.locationtech.jts.geom.Point;
 
 @Entity
 @Getter
@@ -35,7 +35,7 @@ public class Rider extends BaseEntity {
     @Column(name = "is_working", nullable = false)
     private Boolean isWorking;
 
-    @Column(name = "location")
+    @Column(name = "location", columnDefinition = "POINT")
     private Point location;
 
     @Column(name = "preferred_area", nullable = false)

--- a/src/main/java/com/idukbaduk/itseats/store/entity/Store.java
+++ b/src/main/java/com/idukbaduk/itseats/store/entity/Store.java
@@ -9,7 +9,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.data.geo.Point;
+import org.locationtech.jts.geom.Point;
 
 @Entity
 @Getter
@@ -45,7 +45,7 @@ public class Store extends BaseEntity {
     @Column(name = "store_address", nullable = false)
     private String storeAddress;
 
-    @Column(name = "location", nullable = false)
+    @Column(name = "location", columnDefinition = "POINT", nullable = false)
     private Point location;
 
     @Enumerated(EnumType.STRING)

--- a/src/main/java/com/idukbaduk/itseats/store/service/OwnerStoreService.java
+++ b/src/main/java/com/idukbaduk/itseats/store/service/OwnerStoreService.java
@@ -1,5 +1,6 @@
 package com.idukbaduk.itseats.store.service;
 
+import com.idukbaduk.itseats.global.util.GeoUtil;
 import com.idukbaduk.itseats.order.entity.Order;
 import com.idukbaduk.itseats.order.entity.enums.OrderStatus;
 import com.idukbaduk.itseats.order.repository.OrderRepository;
@@ -22,7 +23,6 @@ import com.idukbaduk.itseats.store.repository.StoreCategoryRepository;
 import com.idukbaduk.itseats.store.repository.StoreImageRepository;
 import com.idukbaduk.itseats.store.repository.StoreRepository;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.geo.Point;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -92,8 +92,6 @@ public class OwnerStoreService {
                     .orElseThrow(() -> new StoreException(StoreErrorCode.FRANCHISE_NOT_FOUND));
         }
 
-        Point point = new Point(request.getLng(), request.getLat());
-
         Store store = Store.builder()
                 .member(member)
                 .storeCategory(storeCategory)
@@ -101,7 +99,7 @@ public class OwnerStoreService {
                 .storeName(request.getName())
                 .description(request.getDescription())
                 .storeAddress(request.getAddress())
-                .location(point)
+                .location(GeoUtil.toPoint(request.getLng(), request.getLat()))
                 .storePhone(request.getPhone())
                 .defaultDeliveryFee(request.getDefaultDeliveryFee())
                 .onlyOneDeliveryFee(request.getOnlyOneDeliveryFee())

--- a/src/test/java/com/idukbaduk/itseats/memberaddress/service/MemberAddressServiceTest.java
+++ b/src/test/java/com/idukbaduk/itseats/memberaddress/service/MemberAddressServiceTest.java
@@ -15,7 +15,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.*;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.data.geo.Point;
+import org.locationtech.jts.geom.Point;
 
 import java.util.Optional;
 
@@ -62,8 +62,8 @@ class MemberAddressServiceTest {
         AddressCreateRequest request = AddressCreateRequest.builder()
                 .mainAddress("서울시 구름구 구름로100번길 10")
                 .detailAddress("100호")
-                .locationX(126.9780)
-                .locationY(37.5665)
+                .lng(126.9780)
+                .lat(37.5665)
                 .addressCategory(AddressCategory.HOUSE.name())
                 .build();
 
@@ -92,8 +92,8 @@ class MemberAddressServiceTest {
         assertThat(request.getAddressCategory()).isEqualTo(savedAddress.getAddressCategory().name());
 
         Point point = savedAddress.getLocation();
-        assertThat(point.getX()).isEqualTo(request.getLocationX(), within(0.001));
-        assertThat(point.getY()).isEqualTo(request.getLocationY(), within(0.001));
+        assertThat(point.getX()).isEqualTo(request.getLng(), within(0.001));
+        assertThat(point.getY()).isEqualTo(request.getLat(), within(0.001));
     }
 
     @Test

--- a/src/test/java/com/idukbaduk/itseats/order/service/OrderServiceTest.java
+++ b/src/test/java/com/idukbaduk/itseats/order/service/OrderServiceTest.java
@@ -1,6 +1,7 @@
 package com.idukbaduk.itseats.order.service;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.idukbaduk.itseats.global.util.GeoUtil;
 import com.idukbaduk.itseats.member.entity.Member;
 import com.idukbaduk.itseats.member.repository.MemberRepository;
 import com.idukbaduk.itseats.memberaddress.entity.MemberAddress;
@@ -32,7 +33,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.*;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.data.geo.Point;
+import org.locationtech.jts.geom.Point;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -99,7 +100,7 @@ class OrderServiceTest {
                 .storeName("테스트 구름점")
                 .defaultDeliveryFee(3000)
                 .onlyOneDeliveryFee(3500)
-                .location(new Point(127.0, 37.5))
+                .location(GeoUtil.toPoint(127.0, 37.5))
                 .build();
 
         address = MemberAddress.builder()
@@ -116,8 +117,8 @@ class OrderServiceTest {
                 .orderNumber("A1234B")
                 .orderPrice(10000)
                 .deliveryAddress("서울시 구름구 구름로100번길 10 100호")
-                .destinationLocation(new Point(126.9, 37.4))
-                .storeLocation(new Point(127.0, 37.5))
+                .destinationLocation(GeoUtil.toPoint(126.9, 37.4))
+                .storeLocation(GeoUtil.toPoint(127.0, 37.5))
                 .build();
 
         OrderMenuDTO orderMenuDTO1 = OrderMenuDTO.builder()

--- a/src/test/java/com/idukbaduk/itseats/store/service/OwnerStoreServiceTest.java
+++ b/src/test/java/com/idukbaduk/itseats/store/service/OwnerStoreServiceTest.java
@@ -19,7 +19,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.data.geo.Point;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
@@ -58,8 +57,8 @@ class OwnerStoreServiceTest {
                 .name("테스트가게")
                 .description("설명")
                 .address("서울시 강남구")
-                .locationX(127.0)
-                .locationY(37.5)
+                .lng(127.0)
+                .lat(37.5)
                 .phone("010-1234-5678")
                 .images(List.of(mock(MultipartFile.class)))
                 .isFranchise(true)


### PR DESCRIPTION
## #️⃣연관된 이슈
#86 
closes #86

## 📝작업 내용

### ⭐⭐ _변경되는 Entity의 테이블에 데이터를 넣어두셨으면 삭제가 필요합니다._

Entity와 DTO, Service 클래스에서 Point 클래스를 `org.springframework.data.geo.Point` 에서 `org.locationtech.jts.geom.Point`으로 변경하였습니다. 또한 이를 위한 의존성 `org.hibernate.orm:hibernate-spatial:6.6.18.Final`을 추가하였습니다.

변경된 Entity : Store, Memberaddress, Order, Rider

ST_ 로 시작하는 공간과 관련된 쿼리를 사용하기 위해 `application-local.yml`에 아래 `hibernate.spatial.dialect` 설정을 넣어야 합니다.
```
  jpa:
    database-platform: org.hibernate.spatial.dialect.mysql.MySQL8SpatialDialect
```

요청으로 받은 lng, lat를 Point로 변환할 때는 `GeoUtil.toPoint()` 사용하시면 됩니다!

### 스크린샷 (선택)

![image](https://github.com/user-attachments/assets/10f555b6-bd1d-47d1-8af8-53eab60484de)

결과 DB 컬럼의 자료형이 Point로 변경되었습니다.


## 💬리뷰 요구사항(선택)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
    - 위도 및 경도를 포인트 객체로 변환하는 유틸리티 기능이 추가되었습니다.

- **버그 수정**
    - 주소 및 매장 생성 시 위치 정보를 보다 정확하게 저장하도록 개선되었습니다.

- **스타일**
    - 위치 정보를 나타내는 필드명이 locationX/locationY에서 lng/lat로 변경되어 명확성이 향상되었습니다.
    - 위치 정보 필드의 데이터 타입 및 데이터베이스 컬럼 정의가 공간(Point) 타입으로 명확히 지정되었습니다.

- **테스트**
    - 위치 관련 테스트 코드가 새로운 좌표 필드명과 포인트 변환 방식에 맞게 수정되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->