### PR TITLE
[Feature] 주문 수락 API 구현

### DIFF
--- a/src/main/java/com/idukbaduk/itseats/order/controller/OwnerOrderController.java
+++ b/src/main/java/com/idukbaduk/itseats/order/controller/OwnerOrderController.java
@@ -1,6 +1,7 @@
 package com.idukbaduk.itseats.order.controller;
 
 import com.idukbaduk.itseats.global.response.BaseResponse;
+import com.idukbaduk.itseats.order.dto.OrderAcceptResponse;
 import com.idukbaduk.itseats.order.dto.OrderReceptionResponse;
 import com.idukbaduk.itseats.order.dto.enums.OrderResponse;
 import com.idukbaduk.itseats.order.service.OwnerOrderService;
@@ -17,9 +18,15 @@ public class OwnerOrderController {
 
     private final OwnerOrderService ownerOrderService;
 
-    @GetMapping("/{store_id}/orders")
-    public ResponseEntity<BaseResponse> getOrders(@PathVariable("store_id") Long storeId) {
+    @GetMapping("/{storeId}/orders")
+    public ResponseEntity<BaseResponse> getOrders(@PathVariable("storeId") Long storeId) {
         List<OrderReceptionResponse> orders = ownerOrderService.getOrders(storeId);
         return BaseResponse.toResponseEntity(OrderResponse.GET_STORE_ORDERS_SUCCESS, orders);
+    }
+
+    @PostMapping("/orders/{orderId}/accept")
+    public ResponseEntity<BaseResponse> acceptOrder(@PathVariable("orderId") Long orderId) {
+        OrderAcceptResponse response = ownerOrderService.acceptOrder(orderId);
+        return BaseResponse.toResponseEntity(OrderResponse.ACCEPT_ORDER_SUCCESS, response);
     }
 }

--- a/src/main/java/com/idukbaduk/itseats/order/dto/OrderAcceptResponse.java
+++ b/src/main/java/com/idukbaduk/itseats/order/dto/OrderAcceptResponse.java
@@ -1,0 +1,10 @@
+package com.idukbaduk.itseats.order.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class OrderAcceptResponse {
+    private final boolean success;
+}

--- a/src/main/java/com/idukbaduk/itseats/order/dto/enums/OrderResponse.java
+++ b/src/main/java/com/idukbaduk/itseats/order/dto/enums/OrderResponse.java
@@ -10,6 +10,7 @@ public enum OrderResponse implements Response {
     GET_ORDER_DETAILS_SUCCESS(HttpStatus.OK, "주문 정보 상세 조회 성공"),
     GET_ORDER_STATUS_SUCCESS(HttpStatus.OK, "주문 현황 조회 성공"),
     GET_STORE_ORDERS_SUCCESS(HttpStatus.OK, "주문 접수 조회 성공"),
+    ACCEPT_ORDER_SUCCESS(HttpStatus.OK, "주문 수락 성공"),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/idukbaduk/itseats/order/entity/enums/OrderStatus.java
+++ b/src/main/java/com/idukbaduk/itseats/order/entity/enums/OrderStatus.java
@@ -15,8 +15,12 @@ public enum OrderStatus {
     CANCELED(null),
     // 주문 접수 중
     WAITING(null),
-    // 주문 조리 (주문 접수)
-    COOKING(WAITING),
+    // 주문 수락
+    ACCEPTED(WAITING),
+    // 주문 거절
+    REJECTED(WAITING),
+    // 주문 조리
+    COOKING(ACCEPTED),
     // 조리 완료 (라이더 배차 시작)
     COOKED(COOKING),
     // 배차 완료

--- a/src/main/java/com/idukbaduk/itseats/order/error/enums/OrderErrorCode.java
+++ b/src/main/java/com/idukbaduk/itseats/order/error/enums/OrderErrorCode.java
@@ -10,7 +10,9 @@ public enum OrderErrorCode implements ErrorCode {
     MENU_OPTION_SERIALIZATION_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "menuOption 직렬화 실패"),
     ORDER_NOT_FOUND(HttpStatus.NOT_FOUND, "주문 조회 실패"),
     ORDER_STATUS_UPDATE_FAIL(HttpStatus.CONFLICT, "주문 상태 변경 실패"),
-    ORDER_ALREADY_ASSIGNED(HttpStatus.CONFLICT, "해당 주문은 이미 라이더가 배정되었습니다.");
+    ORDER_ALREADY_ASSIGNED(HttpStatus.CONFLICT, "해당 주문은 이미 라이더가 배정되었습니다."),
+    INVALID_ORDER_STATUS(HttpStatus.CONFLICT, "잘못된 주문 상태입니다."),
+    ;
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/idukbaduk/itseats/order/service/OwnerOrderService.java
+++ b/src/main/java/com/idukbaduk/itseats/order/service/OwnerOrderService.java
@@ -78,6 +78,11 @@ public class OwnerOrderService {
         Order order = orderRepository.findById(orderId)
                 .orElseThrow(() -> new OrderException(OrderErrorCode.ORDER_NOT_FOUND));
 
+
+        if (order.getOrderStatus() != OrderStatus.WAITING) {
+            throw new OrderException(OrderErrorCode.INVALID_ORDER_STATUS);
+        }
+
         order.updateStatus(OrderStatus.ACCEPTED);
 
         return new OrderAcceptResponse(true);

--- a/src/main/java/com/idukbaduk/itseats/order/service/OwnerOrderService.java
+++ b/src/main/java/com/idukbaduk/itseats/order/service/OwnerOrderService.java
@@ -1,9 +1,13 @@
 package com.idukbaduk.itseats.order.service;
 
+import com.idukbaduk.itseats.order.dto.OrderAcceptResponse;
 import com.idukbaduk.itseats.order.dto.OrderReceptionDTO;
 import com.idukbaduk.itseats.order.dto.OrderReceptionResponse;
 import com.idukbaduk.itseats.order.entity.Order;
 import com.idukbaduk.itseats.order.entity.OrderMenu;
+import com.idukbaduk.itseats.order.entity.enums.OrderStatus;
+import com.idukbaduk.itseats.order.error.OrderException;
+import com.idukbaduk.itseats.order.error.enums.OrderErrorCode;
 import com.idukbaduk.itseats.order.repository.OrderRepository;
 import com.idukbaduk.itseats.payment.entity.Payment;
 import com.idukbaduk.itseats.payment.repository.PaymentRepository;
@@ -67,5 +71,15 @@ public class OwnerOrderService {
                 .customerRequest(customerRequest)
                 .riderPhone(riderPhone)
                 .build();
+    }
+
+    @Transactional
+    public OrderAcceptResponse acceptOrder(Long orderId) {
+        Order order = orderRepository.findById(orderId)
+                .orElseThrow(() -> new OrderException(OrderErrorCode.ORDER_NOT_FOUND));
+
+        order.updateStatus(OrderStatus.ACCEPTED);
+
+        return new OrderAcceptResponse(true);
     }
 }

--- a/src/main/java/com/idukbaduk/itseats/order/service/OwnerOrderService.java
+++ b/src/main/java/com/idukbaduk/itseats/order/service/OwnerOrderService.java
@@ -78,11 +78,6 @@ public class OwnerOrderService {
         Order order = orderRepository.findById(orderId)
                 .orElseThrow(() -> new OrderException(OrderErrorCode.ORDER_NOT_FOUND));
 
-
-        if (order.getOrderStatus() != OrderStatus.WAITING) {
-            throw new OrderException(OrderErrorCode.INVALID_ORDER_STATUS);
-        }
-
         order.updateStatus(OrderStatus.ACCEPTED);
 
         return new OrderAcceptResponse(true);

--- a/src/test/java/com/idukbaduk/itseats/order/service/OwnerOrderServiceTest.java
+++ b/src/test/java/com/idukbaduk/itseats/order/service/OwnerOrderServiceTest.java
@@ -121,7 +121,7 @@ class OwnerOrderServiceTest {
     }
 
     @Test
-    @DisplayName("주문이 존재하지 않으면 예외 발생")
+    @DisplayName("주문 수락 시 주문이 존재하지 않으면 예외 발생")
     void acceptOrder_orderNotFound() {
         // given
         Long orderId = 1L;

--- a/src/test/java/com/idukbaduk/itseats/order/service/OwnerOrderServiceTest.java
+++ b/src/test/java/com/idukbaduk/itseats/order/service/OwnerOrderServiceTest.java
@@ -1,10 +1,13 @@
 package com.idukbaduk.itseats.order.service;
 
+import com.idukbaduk.itseats.order.dto.OrderAcceptResponse;
 import com.idukbaduk.itseats.order.dto.OrderReceptionDTO;
 import com.idukbaduk.itseats.order.dto.OrderReceptionResponse;
 import com.idukbaduk.itseats.order.entity.Order;
 import com.idukbaduk.itseats.order.entity.OrderMenu;
 import com.idukbaduk.itseats.order.entity.enums.OrderStatus;
+import com.idukbaduk.itseats.order.error.OrderException;
+import com.idukbaduk.itseats.order.error.enums.OrderErrorCode;
 import com.idukbaduk.itseats.order.repository.OrderRepository;
 import com.idukbaduk.itseats.payment.entity.Payment;
 import com.idukbaduk.itseats.payment.repository.PaymentRepository;
@@ -20,6 +23,8 @@ import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.*;
 import org.junit.jupiter.api.extension.ExtendWith;
 
@@ -97,5 +102,34 @@ class OwnerOrderServiceTest {
 
         List<OrderReceptionResponse> result = ownerOrderService.getOrders(1L);
         assertThat(result.get(0).getCustomerRequest()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("주문 수락 성공")
+    void acceptOrder_success() {
+        // given
+        Long orderId = 1L;
+        Order order = mock(Order.class);
+        given(orderRepository.findById(orderId)).willReturn(Optional.of(order));
+
+        // when
+        OrderAcceptResponse response = ownerOrderService.acceptOrder(orderId);
+
+        // then
+        assertThat(response.isSuccess()).isTrue();
+        then(order).should().updateStatus(OrderStatus.ACCEPTED);
+    }
+
+    @Test
+    @DisplayName("주문이 존재하지 않으면 예외 발생")
+    void acceptOrder_orderNotFound() {
+        // given
+        Long orderId = 1L;
+        given(orderRepository.findById(orderId)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> ownerOrderService.acceptOrder(orderId))
+                .isInstanceOf(OrderException.class)
+                .hasMessage(OrderErrorCode.ORDER_NOT_FOUND.getMessage());
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

#102 

## 📝작업 내용

- [ ] DTO - `OrderAcceptResponse` 추가
- [ ] `OwnerOrderService` 추가
- [ ] `OwnerOrderController` 추가
- [ ] 테스트 코드 추가 및 작동 확인 완료

### 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/cb4b9a33-7343-4ba0-81ff-f998a7439ad8)![image](https://github.com/user-attachments/assets/91c072f4-c215-40a7-947c-a5200703c07c)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 주문 수락 기능이 추가되어, 점주가 주문을 수락할 수 있습니다.
- **버그 수정**
  - 주문 조회 API의 경로 변수명이 일관되게 변경되었습니다.
- **테스트**
  - 주문 수락 기능에 대한 컨트롤러 및 서비스 테스트가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->