### PR TITLE
[Feature] 라이더 주문 정보 조회 API 구현

### DIFF
--- a/src/main/java/com/idukbaduk/itseats/order/controller/RiderOrderController.java
+++ b/src/main/java/com/idukbaduk/itseats/order/controller/RiderOrderController.java
@@ -1,0 +1,31 @@
+package com.idukbaduk.itseats.order.controller;
+
+import com.idukbaduk.itseats.global.response.BaseResponse;
+import com.idukbaduk.itseats.order.dto.enums.OrderResponse;
+import com.idukbaduk.itseats.order.service.RiderOrderService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/rider")
+@RequiredArgsConstructor
+public class RiderOrderController {
+
+    private final RiderOrderService riderOrderService;
+
+    @GetMapping("/{orderId}/details")
+    public ResponseEntity<BaseResponse> getOrderDetails(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @PathVariable("orderId") Long orderId) {
+        return BaseResponse.toResponseEntity(
+                OrderResponse.GET_RIDER_ORDER_DETAILS_SUCCESS,
+                riderOrderService.getOrderDetails(userDetails.getUsername(), orderId)
+        );
+    }
+}

--- a/src/main/java/com/idukbaduk/itseats/order/dto/OrderDetailsResponse.java
+++ b/src/main/java/com/idukbaduk/itseats/order/dto/OrderDetailsResponse.java
@@ -3,7 +3,6 @@ package com.idukbaduk.itseats.order.dto;
 import lombok.Builder;
 import lombok.Getter;
 
-import java.time.LocalDateTime;
 import java.util.List;
 
 @Getter

--- a/src/main/java/com/idukbaduk/itseats/order/dto/OrderDetailsResponse.java
+++ b/src/main/java/com/idukbaduk/itseats/order/dto/OrderDetailsResponse.java
@@ -1,0 +1,23 @@
+package com.idukbaduk.itseats.order.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@Builder
+public class OrderDetailsResponse {
+
+    private Long orderId;
+    private String orderNumber;
+    private String orderStatus;
+    private String orderTime;
+    private int totalPrice;
+    private List<OrderItemDTO> orderItems;
+    private String storePhone;
+    private String memberPhone;
+    private String storeRequest;
+    private String riderRequest;
+}

--- a/src/main/java/com/idukbaduk/itseats/order/dto/OrderItemDTO.java
+++ b/src/main/java/com/idukbaduk/itseats/order/dto/OrderItemDTO.java
@@ -1,0 +1,14 @@
+package com.idukbaduk.itseats.order.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class OrderItemDTO {
+
+    private String menuName;
+    private int quantity;
+    private int menuPrice;
+    private String options;
+}

--- a/src/main/java/com/idukbaduk/itseats/order/dto/enums/OrderResponse.java
+++ b/src/main/java/com/idukbaduk/itseats/order/dto/enums/OrderResponse.java
@@ -10,7 +10,7 @@ public enum OrderResponse implements Response {
     GET_ORDER_DETAILS_SUCCESS(HttpStatus.OK, "주문 정보 상세 조회 성공"),
     GET_ORDER_STATUS_SUCCESS(HttpStatus.OK, "주문 현황 조회 성공"),
     GET_STORE_ORDERS_SUCCESS(HttpStatus.OK, "주문 접수 조회 성공"),
-    ;
+    GET_RIDER_ORDER_DETAILS_SUCCESS(HttpStatus.OK, "주문 정보 조회 성공");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/idukbaduk/itseats/order/service/RiderOrderService.java
+++ b/src/main/java/com/idukbaduk/itseats/order/service/RiderOrderService.java
@@ -1,0 +1,75 @@
+package com.idukbaduk.itseats.order.service;
+
+import com.idukbaduk.itseats.member.entity.Member;
+import com.idukbaduk.itseats.member.error.MemberException;
+import com.idukbaduk.itseats.member.error.enums.MemberErrorCode;
+import com.idukbaduk.itseats.member.repository.MemberRepository;
+import com.idukbaduk.itseats.order.dto.OrderDetailsResponse;
+import com.idukbaduk.itseats.order.dto.OrderItemDTO;
+import com.idukbaduk.itseats.order.entity.Order;
+import com.idukbaduk.itseats.order.error.OrderException;
+import com.idukbaduk.itseats.order.error.enums.OrderErrorCode;
+import com.idukbaduk.itseats.order.repository.OrderRepository;
+import com.idukbaduk.itseats.payment.entity.Payment;
+import com.idukbaduk.itseats.payment.error.PaymentException;
+import com.idukbaduk.itseats.payment.error.enums.PaymentErrorCode;
+import com.idukbaduk.itseats.payment.repository.PaymentRepository;
+import com.idukbaduk.itseats.rider.entity.Rider;
+import com.idukbaduk.itseats.rider.error.RiderException;
+import com.idukbaduk.itseats.rider.error.enums.RiderErrorCode;
+import com.idukbaduk.itseats.rider.repository.RiderRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class RiderOrderService {
+
+    private final OrderRepository orderRepository;
+    private final PaymentRepository paymentRepository;
+    private final RiderRepository riderRepository;
+    private final MemberRepository memberRepository;
+
+
+    public OrderDetailsResponse getOrderDetails(String username, Long orderId) {
+        Member member = memberRepository.findByUsername(username)
+                .orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
+        Rider rider = riderRepository.findByMember(member)
+                .orElseThrow(() -> new RiderException(RiderErrorCode.RIDER_NOT_FOUND));
+
+        Order order = orderRepository.findByRiderAndOrderId(rider, orderId)
+                .orElseThrow(() -> new OrderException(OrderErrorCode.ORDER_NOT_FOUND));
+
+        return buildOrderDetails(order);
+    }
+
+    private OrderDetailsResponse buildOrderDetails(Order order) {
+        Payment payment = paymentRepository.findByOrder(order)
+                .orElseThrow(() -> new PaymentException(PaymentErrorCode.PAYMENT_NOT_FOUND));
+        return OrderDetailsResponse.builder()
+                .orderId(order.getOrderId())
+                .orderNumber(order.getOrderNumber())
+                .orderStatus(order.getOrderStatus().name())
+                .orderTime(order.getCreatedAt().toString())
+                .totalPrice(order.getOrderPrice())
+                .orderItems(buildOrderItems(order))
+                .storePhone(order.getStore().getStorePhone())
+                .memberPhone(order.getMember().getPhone())
+                .storeRequest(payment.getStoreRequest())
+                .riderRequest(payment.getRiderRequest())
+                .build();
+    }
+
+    private List<OrderItemDTO> buildOrderItems(Order order) {
+        return order.getOrderMenus().stream()
+                .map(orderMenu -> OrderItemDTO.builder()
+                        .menuName(orderMenu.getMenuName())
+                        .quantity(orderMenu.getQuantity())
+                        .menuPrice(orderMenu.getPrice())
+                        .options(orderMenu.getMenuOption())
+                        .build())
+                .toList();
+    }
+}

--- a/src/main/java/com/idukbaduk/itseats/order/service/RiderOrderService.java
+++ b/src/main/java/com/idukbaduk/itseats/order/service/RiderOrderService.java
@@ -20,6 +20,7 @@ import com.idukbaduk.itseats.rider.error.enums.RiderErrorCode;
 import com.idukbaduk.itseats.rider.repository.RiderRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
@@ -32,7 +33,7 @@ public class RiderOrderService {
     private final RiderRepository riderRepository;
     private final MemberRepository memberRepository;
 
-
+    @Transactional(readOnly = true)
     public OrderDetailsResponse getOrderDetails(String username, Long orderId) {
         Member member = memberRepository.findByUsername(username)
                 .orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));

--- a/src/test/java/com/idukbaduk/itseats/order/controller/RiderOrderControllerTest.java
+++ b/src/test/java/com/idukbaduk/itseats/order/controller/RiderOrderControllerTest.java
@@ -1,0 +1,66 @@
+package com.idukbaduk.itseats.order.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.idukbaduk.itseats.order.dto.OrderDetailsResponse;
+import com.idukbaduk.itseats.order.dto.enums.OrderResponse;
+import com.idukbaduk.itseats.order.service.RiderOrderService;
+import com.idukbaduk.itseats.rider.dto.ModifyWorkingRequest;
+import com.idukbaduk.itseats.rider.dto.enums.RiderResponse;
+import com.idukbaduk.itseats.rider.error.RiderException;
+import com.idukbaduk.itseats.rider.error.enums.RiderErrorCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.jsonPath;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+
+@WebMvcTest(RiderOrderController.class)
+class RiderOrderControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private RiderOrderService riderOrderService;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    @DisplayName("주문 정보 조회 성공")
+    @WithMockUser(username = "testuser")
+    void getOrderDetails_success() throws Exception {
+        // given
+        Long orderId = 1L;
+        OrderDetailsResponse response = OrderDetailsResponse.builder()
+                .orderId(orderId)
+                .build();
+
+        when(riderOrderService.getOrderDetails(any(), any())).thenReturn(response);
+
+        // when & then
+        mockMvc.perform(get("/api/rider/" + orderId + "/details")
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(response)))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.httpStatus")
+                        .value(OrderResponse.GET_RIDER_ORDER_DETAILS_SUCCESS.getHttpStatus().value()))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.message")
+                        .value(OrderResponse.GET_RIDER_ORDER_DETAILS_SUCCESS.getMessage()))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.orderId").value(orderId));
+    }
+}

--- a/src/test/java/com/idukbaduk/itseats/order/controller/RiderOrderControllerTest.java
+++ b/src/test/java/com/idukbaduk/itseats/order/controller/RiderOrderControllerTest.java
@@ -46,8 +46,7 @@ class RiderOrderControllerTest {
         // when & then
         mockMvc.perform(get("/api/rider/" + orderId + "/details")
                         .with(csrf())
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(response)))
+                        .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(MockMvcResultMatchers.jsonPath("$.httpStatus")
                         .value(OrderResponse.GET_RIDER_ORDER_DETAILS_SUCCESS.getHttpStatus().value()))
                 .andExpect(MockMvcResultMatchers.jsonPath("$.message")

--- a/src/test/java/com/idukbaduk/itseats/order/controller/RiderOrderControllerTest.java
+++ b/src/test/java/com/idukbaduk/itseats/order/controller/RiderOrderControllerTest.java
@@ -4,10 +4,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.idukbaduk.itseats.order.dto.OrderDetailsResponse;
 import com.idukbaduk.itseats.order.dto.enums.OrderResponse;
 import com.idukbaduk.itseats.order.service.RiderOrderService;
-import com.idukbaduk.itseats.rider.dto.ModifyWorkingRequest;
-import com.idukbaduk.itseats.rider.dto.enums.RiderResponse;
-import com.idukbaduk.itseats.rider.error.RiderException;
-import com.idukbaduk.itseats.rider.error.enums.RiderErrorCode;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -18,14 +14,9 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 
-import java.util.Optional;
-
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
-import static org.springframework.test.web.client.match.MockRestRequestMatchers.jsonPath;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 
 @WebMvcTest(RiderOrderController.class)

--- a/src/test/java/com/idukbaduk/itseats/order/service/RiderOrderServiceTest.java
+++ b/src/test/java/com/idukbaduk/itseats/order/service/RiderOrderServiceTest.java
@@ -86,7 +86,7 @@ class RiderOrderServiceTest {
                 .menuName("테스트1")
                 .price(10000)
                 .quantity(2)
-                .menuOption("\"optionName\": \"테스트 옵션1\",\n\"optionPrice\": 5000\n}")
+                .menuOption("\"optionName\": \"테스트 옵션1\",\"optionPrice\": 5000}")
                 .build();
 
         menu2 = OrderMenu.builder()

--- a/src/test/java/com/idukbaduk/itseats/order/service/RiderOrderServiceTest.java
+++ b/src/test/java/com/idukbaduk/itseats/order/service/RiderOrderServiceTest.java
@@ -1,0 +1,187 @@
+package com.idukbaduk.itseats.order.service;
+
+import com.idukbaduk.itseats.member.entity.Member;
+import com.idukbaduk.itseats.member.repository.MemberRepository;
+import com.idukbaduk.itseats.order.dto.OrderDetailsResponse;
+import com.idukbaduk.itseats.order.dto.OrderItemDTO;
+import com.idukbaduk.itseats.order.entity.Order;
+import com.idukbaduk.itseats.order.entity.OrderMenu;
+import com.idukbaduk.itseats.order.entity.enums.OrderStatus;
+import com.idukbaduk.itseats.order.error.OrderException;
+import com.idukbaduk.itseats.order.error.enums.OrderErrorCode;
+import com.idukbaduk.itseats.order.repository.OrderRepository;
+import com.idukbaduk.itseats.payment.entity.Payment;
+import com.idukbaduk.itseats.payment.repository.PaymentRepository;
+import com.idukbaduk.itseats.rider.entity.Rider;
+import com.idukbaduk.itseats.rider.error.RiderException;
+import com.idukbaduk.itseats.rider.error.enums.RiderErrorCode;
+import com.idukbaduk.itseats.rider.repository.RiderRepository;
+import com.idukbaduk.itseats.store.entity.Store;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.lang.reflect.Field;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class RiderOrderServiceTest {
+
+    @Mock
+    private OrderRepository orderRepository;
+    @Mock
+    private PaymentRepository paymentRepository;
+    @Mock
+    private RiderRepository riderRepository;
+    @Mock
+    private MemberRepository memberRepository;
+
+    @InjectMocks
+    private RiderOrderService riderOrderService;
+
+    private final String username = "testuser";
+    private Member member;
+    private Member customer;
+    private Order order;
+    private Rider rider;
+    private Store store;
+    private OrderMenu menu1;
+    private OrderMenu menu2;
+
+    @BeforeEach
+    void setUp() {
+        member = Member.builder()
+                .memberId(1L)
+                .username(username)
+                .build();
+
+        customer = Member.builder()
+                .memberId(2L)
+                .phone("010-0000-0000")
+                .build();
+
+        rider = Rider.builder()
+                .riderId(1L)
+                .member(member)
+                .build();
+
+        store = Store.builder()
+                .storeId(1L)
+                .storePhone("010-1111-2222")
+                .build();
+
+        menu1 = OrderMenu.builder()
+                .orderMenuId(1L)
+                .order(order)
+                .menuName("테스트1")
+                .price(10000)
+                .quantity(2)
+                .menuOption("\"optionName\": \"테스트 옵션1\",\n\"optionPrice\": 5000\n}")
+                .build();
+
+        menu2 = OrderMenu.builder()
+                .orderMenuId(2L)
+                .order(order)
+                .menuName("테스트2")
+                .price(10000)
+                .quantity(1)
+                .menuOption("")
+                .build();
+
+        order = Order.builder()
+                .orderId(1L)
+                .member(customer)
+                .rider(rider)
+                .store(store)
+                .orderNumber("A1234B")
+                .orderPrice(45000)
+                .orderStatus(OrderStatus.COOKING)
+                .orderMenus(List.of(menu1, menu2))
+                .build();
+        setCreatedAt();
+    }
+
+    private void setCreatedAt() {
+        try {
+            Field field = Order.class.getSuperclass().getDeclaredField("createdAt");
+            field.setAccessible(true);
+            field.set(order, LocalDateTime.now());
+        } catch (Exception e) {
+            throw new RuntimeException("createdAt 필드 설정 실패", e);
+        }
+    }
+
+    @Test
+    @DisplayName("라이더 - 주문 정보 조회 성공")
+    void getOrderDetails_success() {
+        // given
+        Payment payment = Payment.builder()
+                .paymentId(1L)
+                .storeRequest("맛있게 만들어주세요")
+                .riderRequest("문 앞에 두고 가주세요")
+                .build();
+
+        when(memberRepository.findByUsername(username)).thenReturn(Optional.of(member));
+        when(riderRepository.findByMember(member)).thenReturn(Optional.of(rider));
+        when(orderRepository.findByRiderAndOrderId(rider, 1L)).thenReturn(Optional.of(order));
+        when(paymentRepository.findByOrder(order)).thenReturn(Optional.of(payment));
+
+        // when
+        OrderDetailsResponse response = riderOrderService.getOrderDetails(username, 1L);
+
+        // then
+        assertThat(response.getOrderId()).isEqualTo(order.getOrderId());
+        assertThat(response.getOrderNumber()).isEqualTo(order.getOrderNumber());
+        assertThat(response.getOrderStatus()).isEqualTo(order.getOrderStatus().name());
+        assertThat(response.getTotalPrice()).isEqualTo(order.getOrderPrice());
+        assertThat(response.getOrderTime()).isEqualTo(order.getCreatedAt().toString());
+        assertThat(response.getOrderItems()).hasSize(2);
+        assertThat(response.getStorePhone()).isEqualTo(store.getStorePhone());
+        assertThat(response.getMemberPhone()).isEqualTo(customer.getPhone());
+        assertThat(response.getStoreRequest()).isEqualTo(payment.getStoreRequest());
+        assertThat(response.getRiderRequest()).isEqualTo(payment.getRiderRequest());
+
+        OrderItemDTO orderItemDto = response.getOrderItems().get(0);
+        assertThat(orderItemDto.getMenuName()).isEqualTo(menu1.getMenuName());
+        assertThat(orderItemDto.getQuantity()).isEqualTo(menu1.getQuantity());
+        assertThat(orderItemDto.getMenuPrice()).isEqualTo(menu1.getPrice());
+        assertThat(orderItemDto.getOptions()).isEqualTo(menu1.getMenuOption());
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 라이더 조회시 예외 발생")
+    void getOrderDetails_notExistRider(){
+        // given
+        when(memberRepository.findByUsername(username)).thenReturn(Optional.of(member));
+        when(riderRepository.findByMember(member)).thenReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> riderOrderService.getOrderDetails(username, 1L))
+                .isInstanceOf(RiderException.class)
+                .hasMessageContaining(RiderErrorCode.RIDER_NOT_FOUND.getMessage());
+    }
+
+    @Test
+    @DisplayName("배차되지 않은 주문을 조회하는 경우 예외 발생")
+    void getOrderDetails_notAssignOrder() {
+        // given
+        when(memberRepository.findByUsername(username)).thenReturn(Optional.of(member));
+        when(riderRepository.findByMember(member)).thenReturn(Optional.of(rider));
+        when(orderRepository.findByRiderAndOrderId(rider, 1L)).thenReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> riderOrderService.getOrderDetails(username, 1L))
+                .isInstanceOf(OrderException.class)
+                .hasMessageContaining(OrderErrorCode.ORDER_NOT_FOUND.getMessage());
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

#95 

## 📝작업 내용

- 해당 라이더가 배차된 주문 ID로 주문 정보(주문 번호, 주문 상태, 주문 일시, 총 금액, 주문 리스트 등)를 응답으로 반환합니다.
---
- DTO `OrderResponse`, `OrderDetailsResponse`, `OrderItemsDTO` 구현 완료
- Service `RiderOrderService` 구현 완료
- Controller `RiderOrderController` 구현 완료
- Test `RiderOrderControllerTest`, `RiderOrderServiceTest` 구현 및 작동 확인 완료

#### 이 PR 이후 배달 수락, 배달 완료, 픽업 완료 로직을 `Rider`에서 `RiderOrder`로 이동하는 작업을 진행할 예정입니다.

### 스크린샷

![image](https://github.com/user-attachments/assets/0594377d-d733-419d-92bc-9683a2acfa07)

![image](https://github.com/user-attachments/assets/d46e739d-a26f-4116-b846-9cd9f2e95c70)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
    - 라이더가 자신의 주문 상세 정보를 조회할 수 있는 API가 추가되었습니다.
- **테스트**
    - 라이더 주문 상세 조회 기능에 대한 컨트롤러 및 서비스 단위 테스트가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->