### PR TITLE
[Feature] 조리 완료 API 구현

### DIFF
--- a/src/main/java/com/idukbaduk/itseats/order/controller/OwnerOrderController.java
+++ b/src/main/java/com/idukbaduk/itseats/order/controller/OwnerOrderController.java
@@ -1,6 +1,7 @@
 package com.idukbaduk.itseats.order.controller;
 
 import com.idukbaduk.itseats.global.response.BaseResponse;
+import com.idukbaduk.itseats.order.dto.OrderCookedResponse;
 import com.idukbaduk.itseats.order.dto.OrderDetailResponse;
 import com.idukbaduk.itseats.order.dto.OrderAcceptResponse;
 import com.idukbaduk.itseats.order.dto.OrderReceptionResponse;
@@ -36,5 +37,11 @@ public class OwnerOrderController {
     public ResponseEntity<BaseResponse> acceptOrder(@PathVariable("orderId") Long orderId) {
         OrderAcceptResponse response = ownerOrderService.acceptOrder(orderId);
         return BaseResponse.toResponseEntity(OrderResponse.ACCEPT_ORDER_SUCCESS, response);
+    }
+
+    @PostMapping("/orders/{orderId}/ready")
+    public ResponseEntity<BaseResponse> cookingComplete(@PathVariable("orderId") Long orderId) {
+        OrderCookedResponse response = ownerOrderService.markAsCooked(orderId);
+        return BaseResponse.toResponseEntity(OrderResponse.COOKED_SUCCESS, response);
     }
 }

--- a/src/main/java/com/idukbaduk/itseats/order/dto/OrderCookedResponse.java
+++ b/src/main/java/com/idukbaduk/itseats/order/dto/OrderCookedResponse.java
@@ -1,0 +1,10 @@
+package com.idukbaduk.itseats.order.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class OrderCookedResponse {
+    private boolean success;
+}

--- a/src/main/java/com/idukbaduk/itseats/order/dto/enums/OrderResponse.java
+++ b/src/main/java/com/idukbaduk/itseats/order/dto/enums/OrderResponse.java
@@ -11,7 +11,8 @@ public enum OrderResponse implements Response {
     GET_ORDER_STATUS_SUCCESS(HttpStatus.OK, "주문 현황 조회 성공"),
     GET_STORE_ORDERS_SUCCESS(HttpStatus.OK, "주문 접수 조회 성공"),
     ACCEPT_ORDER_SUCCESS(HttpStatus.OK, "주문 수락 성공"),
-    GET_RIDER_ORDER_DETAILS_SUCCESS(HttpStatus.OK, "주문 정보 조회 성공");
+    GET_RIDER_ORDER_DETAILS_SUCCESS(HttpStatus.OK, "주문 정보 조회 성공"),
+    COOKED_SUCCESS(HttpStatus.OK,"조리완료");
 
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/idukbaduk/itseats/order/service/OwnerOrderService.java
+++ b/src/main/java/com/idukbaduk/itseats/order/service/OwnerOrderService.java
@@ -1,15 +1,11 @@
 package com.idukbaduk.itseats.order.service;
 
-import com.idukbaduk.itseats.order.dto.OrderDetailResponse;
-import com.idukbaduk.itseats.order.dto.OrderMenuItemDTO;
+import com.idukbaduk.itseats.order.dto.*;
 import com.idukbaduk.itseats.order.entity.Order;
 import com.idukbaduk.itseats.order.entity.OrderMenu;
 import com.idukbaduk.itseats.order.error.OrderException;
 import com.idukbaduk.itseats.order.error.enums.OrderErrorCode;
 import com.idukbaduk.itseats.order.repository.OrderRepository;
-import com.idukbaduk.itseats.order.dto.OrderAcceptResponse;
-import com.idukbaduk.itseats.order.dto.OrderReceptionDTO;
-import com.idukbaduk.itseats.order.dto.OrderReceptionResponse;
 import com.idukbaduk.itseats.order.entity.Order;
 import com.idukbaduk.itseats.order.entity.OrderMenu;
 import com.idukbaduk.itseats.order.entity.enums.OrderStatus;
@@ -128,5 +124,15 @@ public class OwnerOrderService {
         order.updateStatus(OrderStatus.ACCEPTED);
 
         return new OrderAcceptResponse(true);
+    }
+
+    @Transactional
+    public OrderCookedResponse markAsCooked(Long orderId) {
+        Order order = orderRepository.findById(orderId)
+                .orElseThrow(() -> new OrderException(OrderErrorCode.ORDER_NOT_FOUND));
+
+        order.updateStatus(OrderStatus.COOKED);
+
+        return new OrderCookedResponse(true);
     }
 }

--- a/src/test/java/com/idukbaduk/itseats/order/service/OwnerOrderServiceTest.java
+++ b/src/test/java/com/idukbaduk/itseats/order/service/OwnerOrderServiceTest.java
@@ -1,11 +1,7 @@
 package com.idukbaduk.itseats.order.service;
 
 import com.idukbaduk.itseats.menu.entity.Menu;
-import com.idukbaduk.itseats.order.dto.OrderDetailResponse;
-import com.idukbaduk.itseats.order.dto.OrderMenuItemDTO;
-import com.idukbaduk.itseats.order.dto.OrderAcceptResponse;
-import com.idukbaduk.itseats.order.dto.OrderReceptionDTO;
-import com.idukbaduk.itseats.order.dto.OrderReceptionResponse;
+import com.idukbaduk.itseats.order.dto.*;
 import com.idukbaduk.itseats.order.entity.Order;
 import com.idukbaduk.itseats.order.entity.OrderMenu;
 import com.idukbaduk.itseats.order.entity.enums.OrderStatus;
@@ -100,7 +96,7 @@ class OwnerOrderServiceTest {
                 .isInstanceOf(OrderException.class)
                 .hasMessageContaining(OrderErrorCode.ORDER_NOT_FOUND.getMessage());
     }
-    
+
     @Test
     @DisplayName("가게 주문 목록 정상 조회")
     void getOrders_success() {
@@ -190,6 +186,35 @@ class OwnerOrderServiceTest {
 
         // when & then
         assertThatThrownBy(() -> ownerOrderService.acceptOrder(orderId))
+                .isInstanceOf(OrderException.class)
+                .hasMessage(OrderErrorCode.ORDER_NOT_FOUND.getMessage());
+    }
+
+    @Test
+    @DisplayName("조리 완료 성공")
+    void markAsCooked_success() {
+        // given
+        Long orderId = 1L;
+        Order order = mock(Order.class);
+        given(orderRepository.findById(orderId)).willReturn(Optional.of(order));
+
+        // when
+        OrderCookedResponse response = ownerOrderService.markAsCooked(orderId);
+
+        // then
+        assertThat(response.isSuccess()).isTrue();
+        then(order).should().updateStatus(OrderStatus.COOKED);
+    }
+
+    @Test
+    @DisplayName("조리 완료 상태 변경 시 주문이 존재하지 않으면 예외 발생")
+    void markAsCooked_orderNotFound() {
+        // given
+        Long orderId = 1L;
+        given(orderRepository.findById(orderId)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> ownerOrderService.markAsCooked(orderId))
                 .isInstanceOf(OrderException.class)
                 .hasMessage(OrderErrorCode.ORDER_NOT_FOUND.getMessage());
     }


### PR DESCRIPTION
## #️⃣연관된 이슈

#104 

## 📝작업 내용
- [ ] DTO - `OrderCookedResponse` 작성
- [ ] `OwnerOrderService`, `OwnerOrderController`에 조리 완료 메서드 추가
- [ ] 테스트 코드 작성 및 작동 확인 완료

### 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/7a2b5e0c-7c84-4edf-bcb0-9cb3dfefb9ef)
![image](https://github.com/user-attachments/assets/49ce9194-ae1a-4d33-91f6-f4e40f8cae64)


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
    - 주문을 조리 완료 상태로 변경하는 새로운 엔드포인트가 추가되었습니다.
- **버그 수정**
    - 주문이 존재하지 않을 경우 적절한 오류 메시지와 상태 코드가 반환됩니다.
- **테스트**
    - 조리 완료 기능에 대한 성공 및 실패 케이스 테스트가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->