### PR TITLE
[Feature] 배달 상태 촬영 API 구현

### DIFF
--- a/src/main/java/com/idukbaduk/itseats/order/controller/RiderOrderController.java
+++ b/src/main/java/com/idukbaduk/itseats/order/controller/RiderOrderController.java
@@ -6,6 +6,7 @@ import com.idukbaduk.itseats.order.entity.enums.OrderStatus;
 import com.idukbaduk.itseats.order.service.RiderOrderService;
 import com.idukbaduk.itseats.rider.dto.enums.RiderResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -13,7 +14,9 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 
 @RestController
 @RequestMapping("/api/rider")
@@ -46,6 +49,17 @@ public class RiderOrderController {
             @PathVariable("orderId") Long orderId) {
         riderOrderService.updateOrderStatusAfterAccept(userDetails.getUsername(), orderId, OrderStatus.DELIVERING);
         return BaseResponse.toResponseEntity(RiderResponse.UPDATE_STATUS_PICKUP_SUCCESS);
+    }
+
+    @PostMapping(path = "/{orderId}/picture", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<BaseResponse> uploadRiderImage(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @PathVariable("orderId") Long orderId,
+            @RequestParam("image") MultipartFile image) {
+        return BaseResponse.toResponseEntity(
+                OrderResponse.UPLOAD_RIDER_IMAGE_SUCCESS,
+                riderOrderService.uploadRiderImage(userDetails.getUsername(), orderId, image)
+        );
     }
 
     @PostMapping("/{orderId}/done")

--- a/src/main/java/com/idukbaduk/itseats/order/dto/RiderImageResponse.java
+++ b/src/main/java/com/idukbaduk/itseats/order/dto/RiderImageResponse.java
@@ -1,0 +1,11 @@
+package com.idukbaduk.itseats.order.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class RiderImageResponse {
+
+    private String image;
+}

--- a/src/main/java/com/idukbaduk/itseats/order/dto/enums/OrderResponse.java
+++ b/src/main/java/com/idukbaduk/itseats/order/dto/enums/OrderResponse.java
@@ -13,7 +13,8 @@ public enum OrderResponse implements Response {
     REJECT_ORDER_SUCCESS(HttpStatus.OK, "주문 거절 완료"),
     ACCEPT_ORDER_SUCCESS(HttpStatus.OK, "주문 수락 성공"),
     GET_RIDER_ORDER_DETAILS_SUCCESS(HttpStatus.OK, "주문 정보 조회 성공"),
-    COOKED_SUCCESS(HttpStatus.OK,"조리완료");
+    COOKED_SUCCESS(HttpStatus.OK,"조리완료"),
+    UPLOAD_RIDER_IMAGE_SUCCESS(HttpStatus.CREATED,"배달 상태 촬영 업로드 성공");
 
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/idukbaduk/itseats/order/error/enums/OrderErrorCode.java
+++ b/src/main/java/com/idukbaduk/itseats/order/error/enums/OrderErrorCode.java
@@ -12,7 +12,7 @@ public enum OrderErrorCode implements ErrorCode {
     ORDER_STATUS_UPDATE_FAIL(HttpStatus.CONFLICT, "주문 상태 변경 실패"),
     ORDER_ALREADY_ASSIGNED(HttpStatus.CONFLICT, "해당 주문은 이미 라이더가 배정되었습니다."),
     INVALID_ORDER_STATUS(HttpStatus.CONFLICT, "잘못된 주문 상태입니다."),
-    ;
+    REQUIRED_RIDER_IMAGE(HttpStatus.BAD_REQUEST, "배달 상태 이미지는 필수입니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/idukbaduk/itseats/order/repository/RiderImageRepository.java
+++ b/src/main/java/com/idukbaduk/itseats/order/repository/RiderImageRepository.java
@@ -1,0 +1,9 @@
+package com.idukbaduk.itseats.order.repository;
+
+import com.idukbaduk.itseats.order.entity.RiderImage;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface RiderImageRepository extends JpaRepository<RiderImage, Long> {
+}

--- a/src/main/java/com/idukbaduk/itseats/order/service/RiderImageService.java
+++ b/src/main/java/com/idukbaduk/itseats/order/service/RiderImageService.java
@@ -1,0 +1,31 @@
+package com.idukbaduk.itseats.order.service;
+
+import com.idukbaduk.itseats.order.entity.Order;
+import com.idukbaduk.itseats.order.entity.RiderImage;
+import com.idukbaduk.itseats.order.repository.RiderImageRepository;
+import com.idukbaduk.itseats.rider.entity.Rider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+@Service
+@RequiredArgsConstructor
+public class RiderImageService {
+
+    private final RiderImageRepository riderImageRepository;
+
+    public RiderImage saveRiderImage(Rider rider, Order order, MultipartFile image) {
+        return riderImageRepository.save(
+                RiderImage.builder()
+                        .imageUrl(generateImageUrl(image))
+                        .rider(rider)
+                        .order(order)
+                        .build()
+        );
+    }
+
+    private String generateImageUrl(MultipartFile image) {
+        // 임시 파일명 기반 URL
+        return "https://example.com/" + image.getOriginalFilename();
+    }
+}

--- a/src/main/java/com/idukbaduk/itseats/order/service/RiderOrderService.java
+++ b/src/main/java/com/idukbaduk/itseats/order/service/RiderOrderService.java
@@ -6,6 +6,7 @@ import com.idukbaduk.itseats.member.error.enums.MemberErrorCode;
 import com.idukbaduk.itseats.member.repository.MemberRepository;
 import com.idukbaduk.itseats.order.dto.OrderDetailsResponse;
 import com.idukbaduk.itseats.order.dto.OrderItemDTO;
+import com.idukbaduk.itseats.order.dto.RiderImageResponse;
 import com.idukbaduk.itseats.order.entity.Order;
 import com.idukbaduk.itseats.order.entity.enums.OrderStatus;
 import com.idukbaduk.itseats.order.error.OrderException;
@@ -22,6 +23,7 @@ import com.idukbaduk.itseats.rider.repository.RiderRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 
@@ -33,6 +35,7 @@ public class RiderOrderService {
     private final PaymentRepository paymentRepository;
     private final RiderRepository riderRepository;
     private final MemberRepository memberRepository;
+    private final RiderImageService riderImageService;
 
     @Transactional(readOnly = true)
     public OrderDetailsResponse getOrderDetails(String username, Long orderId) {
@@ -99,5 +102,28 @@ public class RiderOrderService {
                 .orElseThrow(() -> new OrderException(OrderErrorCode.ORDER_NOT_FOUND));
 
         order.updateStatus(orderStatus);
+    }
+
+    public RiderImageResponse uploadRiderImage(String username, Long orderId, MultipartFile image) {
+        if (image == null || image.isEmpty()) {
+            throw new OrderException(OrderErrorCode.REQUIRED_RIDER_IMAGE);
+        }
+
+        Member member = memberRepository.findByUsername(username)
+                .orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
+        Rider rider = riderRepository.findByMember(member)
+                .orElseThrow(() -> new RiderException(RiderErrorCode.RIDER_NOT_FOUND));
+        Order order = orderRepository.findByRiderAndOrderId(rider, orderId)
+                .orElseThrow(() -> new OrderException(OrderErrorCode.ORDER_NOT_FOUND));
+
+        return buildRiderImageResponse(
+                riderImageService.saveRiderImage(rider, order, image).getImageUrl()
+        );
+    }
+
+    private RiderImageResponse buildRiderImageResponse(String imageUrl) {
+        return RiderImageResponse.builder()
+                .image(imageUrl)
+                .build();
     }
 }

--- a/src/test/java/com/idukbaduk/itseats/order/controller/RiderOrderControllerTest.java
+++ b/src/test/java/com/idukbaduk/itseats/order/controller/RiderOrderControllerTest.java
@@ -2,6 +2,7 @@ package com.idukbaduk.itseats.order.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.idukbaduk.itseats.order.dto.OrderDetailsResponse;
+import com.idukbaduk.itseats.order.dto.RiderImageResponse;
 import com.idukbaduk.itseats.order.dto.enums.OrderResponse;
 import com.idukbaduk.itseats.order.service.RiderOrderService;
 import com.idukbaduk.itseats.rider.dto.enums.RiderResponse;
@@ -10,15 +11,18 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+import org.springframework.web.multipart.MultipartFile;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -107,5 +111,32 @@ class RiderOrderControllerTest {
                         .value(RiderResponse.UPDATE_STATUS_PICKUP_SUCCESS.getHttpStatus().value()))
                 .andExpect(jsonPath("$.message")
                         .value(RiderResponse.UPDATE_STATUS_PICKUP_SUCCESS.getMessage()));
+    }
+
+    @Test
+    @DisplayName("배달 완료 이미지 업로드 성공")
+    @WithMockUser(username = "testuser")
+    void uploadRiderImage_success() throws Exception {
+        // given
+        long orderId = 1L;
+        MockMultipartFile image = new MockMultipartFile(
+                "image", "test.jpg", "image/jpeg", "test".getBytes()
+        );
+
+        RiderImageResponse response = RiderImageResponse.builder()
+                .image("https://example.com/test.jpg")
+                .build();
+
+        when(riderOrderService.uploadRiderImage(any(), any(), any(MultipartFile.class))).thenReturn(response);
+
+        // when & then
+        mockMvc.perform(multipart("/api/rider/{orderId}/picture", orderId)
+                        .file(image)
+                        .with(csrf())
+                        .contentType(MediaType.MULTIPART_FORM_DATA))
+                .andExpect(jsonPath("$.httpStatus")
+                        .value(OrderResponse.UPLOAD_RIDER_IMAGE_SUCCESS.getHttpStatus().value()))
+                .andExpect(jsonPath("$.message")
+                        .value(OrderResponse.UPLOAD_RIDER_IMAGE_SUCCESS.getMessage()));
     }
 }

--- a/src/test/java/com/idukbaduk/itseats/order/service/RiderImageServiceTest.java
+++ b/src/test/java/com/idukbaduk/itseats/order/service/RiderImageServiceTest.java
@@ -1,0 +1,73 @@
+package com.idukbaduk.itseats.order.service;
+
+import com.idukbaduk.itseats.order.entity.Order;
+import com.idukbaduk.itseats.order.entity.RiderImage;
+import com.idukbaduk.itseats.order.repository.RiderImageRepository;
+import com.idukbaduk.itseats.rider.entity.Rider;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.web.multipart.MultipartFile;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class RiderImageServiceTest {
+
+    @Mock
+    private RiderImageRepository riderImageRepository;
+
+    @InjectMocks
+    private RiderImageService riderImageService;
+
+    private Rider rider;
+    private Order order;
+    private MultipartFile multipartFile;
+    private RiderImage riderImage;
+
+    @BeforeEach
+    void setUp() {
+        rider = Rider.builder()
+                .riderId(1L)
+                .build();
+
+        order = Order.builder()
+                .orderId(1L)
+                .build();
+
+        multipartFile = new MockMultipartFile(
+                "file", "test.jpg", "image/jpeg", "test".getBytes()
+        );
+
+        riderImage = RiderImage.builder()
+                .imageId(1L)
+                .rider(rider)
+                .order(order)
+                .imageUrl("https://example.com/test.jpg")
+                .build();
+    }
+
+    @Test
+    @DisplayName("배달 상태 사진 저장 성공")
+    void saveRiderImage_success() {
+        // given
+        when(riderImageRepository.save(Mockito.any(RiderImage.class))).thenReturn(riderImage);
+
+        // when
+        RiderImage savedRiderImage = riderImageService.saveRiderImage(rider, order, multipartFile);
+
+        // then
+        assertThat(savedRiderImage.getImageId()).isEqualTo(riderImage.getImageId());
+        assertThat(savedRiderImage.getRider()).isEqualTo(rider);
+        assertThat(savedRiderImage.getOrder()).isEqualTo(order);
+        assertThat(savedRiderImage.getImageUrl()).isEqualTo(riderImage.getImageUrl());
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

#109 

## 📝작업 내용

- 배달 상태를 촬영한 이미지를 받아와 이미지를 저장하고 저장된 이미지 URL을 응답으로 반환합니다.
---
- [x] DTO `OrderResponse`, `RiderImageResponse` 구현 완료
- [x] Service `RiderImageService`, `RiderOrderService` 구현 완료
- [x] Controller `RiderOrderController` 구현 완료
- [x] Repository `RiderImageRepository` 구현 완료
- [x] Test `RiderOrderControllerTest`, `RiderOrderServiceTest`, `RiderImageServiceTest` 구현 및 작동 확인 완료

### 스크린샷

![image](https://github.com/user-attachments/assets/40af3cd1-943c-4c55-be9c-bf6d53baa744)

![image](https://github.com/user-attachments/assets/e91e5c2f-c096-4511-b65a-f9b6d07c785d)

![image](https://github.com/user-attachments/assets/7fc2e628-8ba6-40b0-9d5d-50cefe366af1)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
