### PR TITLE
[Feature] 메뉴 수정 API 구현

### DIFF
--- a/src/main/java/com/idukbaduk/itseats/menu/controller/MenuController.java
+++ b/src/main/java/com/idukbaduk/itseats/menu/controller/MenuController.java
@@ -13,6 +13,9 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/owner")
@@ -36,11 +39,12 @@ public class MenuController {
     @PostMapping(value = "/{storeId}/menus/new", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<BaseResponse> createMenu(
             @PathVariable Long storeId,
-            @Valid @ModelAttribute MenuRequest request
+            @Valid @RequestPart("request") MenuRequest request,
+            @RequestPart(value = "images", required = false) List<MultipartFile> images
     ) {
         return BaseResponse.toResponseEntity(
                 MenuResponse.CREATE_MENU_SUCCESS,
-                menuService.createMenu(storeId, request)
+                menuService.createMenu(storeId, request, images)
         );
     }
 
@@ -48,11 +52,12 @@ public class MenuController {
     public ResponseEntity<BaseResponse> updateMenu(
             @PathVariable Long storeId,
             @PathVariable Long menuId,
-            @Valid @ModelAttribute MenuRequest request
+            @Valid @RequestPart("request") MenuRequest request,
+            @RequestPart(value = "images", required = false) List<MultipartFile> images
     ) {
         return BaseResponse.toResponseEntity(
                 MenuResponse.UPDATE_MENU_SUCCESS,
-                menuService.updateMenu(storeId, menuId, request)
+                menuService.updateMenu(storeId, menuId, request, images)
         );
     }
 

--- a/src/main/java/com/idukbaduk/itseats/menu/controller/MenuController.java
+++ b/src/main/java/com/idukbaduk/itseats/menu/controller/MenuController.java
@@ -1,7 +1,10 @@
 package com.idukbaduk.itseats.menu.controller;
 
 import com.idukbaduk.itseats.global.response.BaseResponse;
-import com.idukbaduk.itseats.menu.dto.*;
+import com.idukbaduk.itseats.menu.dto.MenuGroupRequest;
+import com.idukbaduk.itseats.menu.dto.MenuGroupResponse;
+import com.idukbaduk.itseats.menu.dto.MenuListRequest;
+import com.idukbaduk.itseats.menu.dto.MenuRequest;
 import com.idukbaduk.itseats.menu.dto.enums.MenuResponse;
 import com.idukbaduk.itseats.menu.service.MenuGroupService;
 import com.idukbaduk.itseats.menu.service.MenuService;
@@ -10,9 +13,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-import org.springframework.web.multipart.MultipartFile;
-
-import java.util.List;
 
 @RestController
 @RequestMapping("/api/owner")

--- a/src/main/java/com/idukbaduk/itseats/menu/controller/MenuController.java
+++ b/src/main/java/com/idukbaduk/itseats/menu/controller/MenuController.java
@@ -44,6 +44,18 @@ public class MenuController {
         );
     }
 
+    @PutMapping(value = "/{storeId}/menus/{menuId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<BaseResponse> createMenu(
+            @PathVariable Long storeId,
+            @PathVariable Long menuId,
+            @Valid @ModelAttribute MenuRequest request
+    ) {
+        return BaseResponse.toResponseEntity(
+                MenuResponse.UPDATE_MENU_SUCCESS,
+                menuService.updateMenu(storeId, menuId, request)
+        );
+    }
+
     @PostMapping("/{storeId}/menu-groups")
     public ResponseEntity<BaseResponse> saveMenuGroup(
             @PathVariable Long storeId,

--- a/src/main/java/com/idukbaduk/itseats/menu/controller/MenuController.java
+++ b/src/main/java/com/idukbaduk/itseats/menu/controller/MenuController.java
@@ -45,7 +45,7 @@ public class MenuController {
     }
 
     @PutMapping(value = "/{storeId}/menus/{menuId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public ResponseEntity<BaseResponse> createMenu(
+    public ResponseEntity<BaseResponse> updateMenu(
             @PathVariable Long storeId,
             @PathVariable Long menuId,
             @Valid @ModelAttribute MenuRequest request

--- a/src/main/java/com/idukbaduk/itseats/menu/dto/MenuRequest.java
+++ b/src/main/java/com/idukbaduk/itseats/menu/dto/MenuRequest.java
@@ -36,6 +36,4 @@ public class MenuRequest {
 
     @Valid
     List<MenuOptionGroupDto> optionGroups;
-
-    List<MultipartFile> images;
 }

--- a/src/main/java/com/idukbaduk/itseats/menu/dto/enums/MenuResponse.java
+++ b/src/main/java/com/idukbaduk/itseats/menu/dto/enums/MenuResponse.java
@@ -10,7 +10,8 @@ public enum MenuResponse implements Response {
     GET_MENU_LIST_SUCCESS(HttpStatus.OK, "메뉴 목록 조회 성공"),
     GET_MENU_GROUP_SUCCESS(HttpStatus.OK, "메뉴 그룹 조회 성공"),
     SAVE_MENU_GROUP_SUCCESS(HttpStatus.OK, "메뉴 그룹 설정 성공"),
-    CREATE_MENU_SUCCESS(HttpStatus.CREATED, "메뉴 추가 성공")
+    CREATE_MENU_SUCCESS(HttpStatus.CREATED, "메뉴 추가 성공"),
+    UPDATE_MENU_SUCCESS(HttpStatus.OK, "메뉴 수정 성공")
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/idukbaduk/itseats/menu/entity/Menu.java
+++ b/src/main/java/com/idukbaduk/itseats/menu/entity/Menu.java
@@ -51,7 +51,23 @@ public class Menu extends BaseEntity {
     @OneToMany(mappedBy = "menu", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
     private List<MenuOptionGroup> menuOptionGroups = new ArrayList<>();
 
-    public void addMenuOptionGroup(MenuOptionGroup menuOptionGroup) {
-        menuOptionGroups.add(menuOptionGroup);
+    public void setMenuOptionGroups(List<MenuOptionGroup> menuOptionGroups) {
+        // 옵션 그룹 변경을 JPA가 감지하고 기존 옵션을 삭제하도록 clear() 호출
+        this.menuOptionGroups.clear();
+        menuOptionGroups.forEach(menuOptionGroup -> {
+            if (menuOptionGroup.getMenu() != this)
+                menuOptionGroup.setMenu(this);
+        });
+        this.menuOptionGroups.addAll(menuOptionGroups);
+    }
+
+    public void updateMenu(MenuGroup menuGroup, String menuName, Long menuPrice,
+                           MenuStatus menuStatus, String menuDescription, int menuPriority) {
+        this.menuGroup = menuGroup;
+        this.menuName = menuName;
+        this.menuPrice = menuPrice;
+        this.menuStatus = menuStatus;
+        this.menuDescription = menuDescription;
+        this.menuPriority = menuPriority;
     }
 }

--- a/src/main/java/com/idukbaduk/itseats/menu/entity/MenuGroup.java
+++ b/src/main/java/com/idukbaduk/itseats/menu/entity/MenuGroup.java
@@ -3,7 +3,10 @@ package com.idukbaduk.itseats.menu.entity;
 import com.idukbaduk.itseats.global.BaseEntity;
 import com.idukbaduk.itseats.store.entity.Store;
 import jakarta.persistence.*;
-import lombok.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/src/main/java/com/idukbaduk/itseats/menu/entity/MenuImage.java
+++ b/src/main/java/com/idukbaduk/itseats/menu/entity/MenuImage.java
@@ -1,15 +1,7 @@
 package com.idukbaduk.itseats.menu.entity;
 
 import com.idukbaduk.itseats.global.BaseEntity;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.Table;
+import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;

--- a/src/main/java/com/idukbaduk/itseats/menu/entity/MenuOption.java
+++ b/src/main/java/com/idukbaduk/itseats/menu/entity/MenuOption.java
@@ -2,17 +2,7 @@ package com.idukbaduk.itseats.menu.entity;
 
 import com.idukbaduk.itseats.global.BaseEntity;
 import com.idukbaduk.itseats.menu.entity.enums.MenuStatus;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.Table;
+import jakarta.persistence.*;
 import lombok.*;
 
 @Entity

--- a/src/main/java/com/idukbaduk/itseats/menu/entity/MenuOption.java
+++ b/src/main/java/com/idukbaduk/itseats/menu/entity/MenuOption.java
@@ -13,10 +13,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @Entity
 @Getter
@@ -31,6 +28,7 @@ public class MenuOption extends BaseEntity {
     @Column(name = "option_id")
     private Long optionId;
 
+    @Setter
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "opt_group_id", nullable = false)
     private MenuOptionGroup menuOptionGroup;

--- a/src/main/java/com/idukbaduk/itseats/menu/entity/MenuOptionGroup.java
+++ b/src/main/java/com/idukbaduk/itseats/menu/entity/MenuOptionGroup.java
@@ -2,10 +2,7 @@ package com.idukbaduk.itseats.menu.entity;
 
 import com.idukbaduk.itseats.global.BaseEntity;
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -23,6 +20,7 @@ public class MenuOptionGroup extends BaseEntity {
     @Column(name = "opt_group_id")
     private Long optGroupId;
 
+    @Setter
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "menu_id", nullable = false)
     private Menu menu;
@@ -48,5 +46,8 @@ public class MenuOptionGroup extends BaseEntity {
 
     public void addOption(MenuOption menuOption) {
         options.add(menuOption);
+        if (menuOption.getMenuOptionGroup() != this) {
+            menuOption.setMenuOptionGroup(this);
+        }
     }
 }

--- a/src/main/java/com/idukbaduk/itseats/menu/repository/MenuGroupRepository.java
+++ b/src/main/java/com/idukbaduk/itseats/menu/repository/MenuGroupRepository.java
@@ -1,7 +1,6 @@
 package com.idukbaduk.itseats.menu.repository;
 
 import com.idukbaduk.itseats.menu.entity.MenuGroup;
-import com.idukbaduk.itseats.store.entity.Store;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;

--- a/src/main/java/com/idukbaduk/itseats/menu/repository/MenuImageRepository.java
+++ b/src/main/java/com/idukbaduk/itseats/menu/repository/MenuImageRepository.java
@@ -11,4 +11,6 @@ public interface MenuImageRepository extends JpaRepository<MenuImage, Long> {
     Optional<MenuImage> findFirstByMenu_MenuIdOrderByDisplayOrderAsc(Long menuId);
 
     List<MenuImage> findByMenu_MenuIdInOrderByMenu_MenuIdAscDisplayOrderAsc(List<Long> menuIds);
+
+    List<MenuImage> findByMenu_MenuIdOrderByDisplayOrderAsc(Long menuId);
 }

--- a/src/main/java/com/idukbaduk/itseats/menu/repository/MenuOptionRepository.java
+++ b/src/main/java/com/idukbaduk/itseats/menu/repository/MenuOptionRepository.java
@@ -3,7 +3,5 @@ package com.idukbaduk.itseats.menu.repository;
 import com.idukbaduk.itseats.menu.entity.MenuOption;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.util.List;
-
 public interface MenuOptionRepository extends JpaRepository<MenuOption, Long> {
 }

--- a/src/main/java/com/idukbaduk/itseats/menu/repository/MenuRepository.java
+++ b/src/main/java/com/idukbaduk/itseats/menu/repository/MenuRepository.java
@@ -21,6 +21,12 @@ public interface MenuRepository extends JpaRepository<Menu, Long> {
             @Param("menuGroup") String menuGroup,
             @Param("keyword") String keyword
     );
+
+    @Query("SELECT m FROM Menu m " +
+            "JOIN FETCH m.menuGroup mg " +
+            "WHERE m.menuId = :menuId " +
+            "AND mg.store.storeId = :storeId")
+    Optional<Menu> findByStoreIdAndMenuId(Long storeId, Long menuId);
   
     Optional<Menu> findByMenuIdAndDeletedFalse(Long menuId);
 

--- a/src/main/java/com/idukbaduk/itseats/menu/service/MenuGroupService.java
+++ b/src/main/java/com/idukbaduk/itseats/menu/service/MenuGroupService.java
@@ -1,11 +1,9 @@
 package com.idukbaduk.itseats.menu.service;
 
-import com.idukbaduk.itseats.menu.dto.*;
-import com.idukbaduk.itseats.menu.entity.Menu;
+import com.idukbaduk.itseats.menu.dto.MenuGroupDto;
+import com.idukbaduk.itseats.menu.dto.MenuGroupRequest;
+import com.idukbaduk.itseats.menu.dto.MenuGroupResponse;
 import com.idukbaduk.itseats.menu.entity.MenuGroup;
-import com.idukbaduk.itseats.menu.entity.enums.MenuStatus;
-import com.idukbaduk.itseats.menu.error.MenuErrorCode;
-import com.idukbaduk.itseats.menu.error.MenuException;
 import com.idukbaduk.itseats.menu.repository.MenuGroupRepository;
 import com.idukbaduk.itseats.menu.repository.MenuRepository;
 import com.idukbaduk.itseats.store.entity.Store;

--- a/src/main/java/com/idukbaduk/itseats/menu/service/MenuMediaService.java
+++ b/src/main/java/com/idukbaduk/itseats/menu/service/MenuMediaService.java
@@ -4,6 +4,7 @@ import com.idukbaduk.itseats.menu.entity.Menu;
 import com.idukbaduk.itseats.menu.entity.MenuImage;
 import com.idukbaduk.itseats.menu.repository.MenuImageRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -11,6 +12,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class MenuMediaService {
@@ -23,24 +25,23 @@ public class MenuMediaService {
             return Collections.emptyList();
 
         // 이미지 파일 유효성 검증
-        validateImageFile(images);
+        images = filterValidImages(images);
 
         return saveMenuImages(menu, images);
     }
 
     public List<MenuImage> updateMenuImages(Menu menu, List<MultipartFile> images) {
         List<MenuImage> existingImages = menuImageRepository.findByMenu_MenuIdOrderByDisplayOrderAsc(menu.getMenuId());
-
         if (images == null) {
             // form-data에 images를 추가하지 않았다면 현재 상태 유지
             return existingImages;
         }
 
-        // 이미지 파일 유효성 검증
-        validateImageFile(images);
-
         // 기존 이미지 삭제
         menuImageRepository.deleteAll(existingImages);
+
+        // 이미지 파일 유효성 검증
+        images = filterValidImages(images);
 
         // 빈 배열이면 빈 리스트 반환
         if (images.isEmpty()) {
@@ -51,12 +52,12 @@ public class MenuMediaService {
         return saveMenuImages(menu, images);
     }
 
-    private void validateImageFile(List<MultipartFile> images) {
-        for (MultipartFile image : images) {
-            if (image.isEmpty()) {
-                throw new IllegalArgumentException("Empty image file is not allowed");
-            }
-        }
+    private List<MultipartFile> filterValidImages(List<MultipartFile> images) {
+        if (images == null) return Collections.emptyList();
+
+        return images.stream()
+                .filter(image -> !image.isEmpty())
+                .toList();
     }
 
     private List<MenuImage> saveMenuImages(Menu menu, List<MultipartFile> images) {

--- a/src/main/java/com/idukbaduk/itseats/menu/service/MenuMediaService.java
+++ b/src/main/java/com/idukbaduk/itseats/menu/service/MenuMediaService.java
@@ -16,7 +16,7 @@ import java.util.List;
 @Service
 @RequiredArgsConstructor
 public class MenuMediaService {
-    // TODO S3에서 이미지 파일 저장 및 삭제
+    // TODO: S3에서 이미지 파일 저장 및 삭제
 
     private final MenuImageRepository menuImageRepository;
 

--- a/src/main/java/com/idukbaduk/itseats/menu/service/MenuMediaService.java
+++ b/src/main/java/com/idukbaduk/itseats/menu/service/MenuMediaService.java
@@ -14,6 +14,7 @@ import java.util.List;
 @Service
 @RequiredArgsConstructor
 public class MenuMediaService {
+    // TODO S3에서 이미지 파일 저장 및 삭제
 
     private final MenuImageRepository menuImageRepository;
 
@@ -22,12 +23,43 @@ public class MenuMediaService {
             return Collections.emptyList();
 
         // 이미지 파일 유효성 검증
+        validateImageFile(images);
+
+        return saveMenuImages(menu, images);
+    }
+
+    public List<MenuImage> updateMenuImages(Menu menu, List<MultipartFile> images) {
+        List<MenuImage> existingImages = menuImageRepository.findByMenu_MenuIdOrderByDisplayOrderAsc(menu.getMenuId());
+
+        if (images == null) {
+            // form-data에 images를 추가하지 않았다면 현재 상태 유지
+            return existingImages;
+        }
+
+        // 이미지 파일 유효성 검증
+        validateImageFile(images);
+
+        // 기존 이미지 삭제
+        menuImageRepository.deleteAll(existingImages);
+
+        // 빈 배열이면 빈 리스트 반환
+        if (images.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        // 새 이미지 저장
+        return saveMenuImages(menu, images);
+    }
+
+    private void validateImageFile(List<MultipartFile> images) {
         for (MultipartFile image : images) {
             if (image.isEmpty()) {
                 throw new IllegalArgumentException("Empty image file is not allowed");
             }
         }
+    }
 
+    private List<MenuImage> saveMenuImages(Menu menu, List<MultipartFile> images) {
         List<MenuImage> menuImages = new ArrayList<>();
         for (int i = 0; i < images.size(); i++) {
             String imageUrl = generateImageUrl(images.get(i));

--- a/src/main/java/com/idukbaduk/itseats/menu/service/MenuService.java
+++ b/src/main/java/com/idukbaduk/itseats/menu/service/MenuService.java
@@ -93,7 +93,7 @@ public class MenuService {
         validateDuplicateOptionGroupNames(request.getOptionGroups());
         validateOptionSelectRange(request.getOptionGroups());
 
-        updateMenu(request, menu, menuGroup); // menu 필드 업데이트
+        updateMenuFields(request, menu, menuGroup); // menu 필드 업데이트
         menu.setMenuOptionGroups(createOptionGroups(menu, request.getOptionGroups())); // 옵션 그룹 삭제 후 추가
         Menu savedMenu = menuRepository.save(menu); // cascade에 의해 옵션도 모두 저장됨
 
@@ -138,7 +138,7 @@ public class MenuService {
                 .build();
     }
 
-    private void updateMenu(MenuRequest request, Menu menu, MenuGroup menuGroup) {
+    private void updateMenuFields(MenuRequest request, Menu menu, MenuGroup menuGroup) {
         menu.updateMenu(
                 menuGroup,
                 request.getMenuName(),

--- a/src/main/java/com/idukbaduk/itseats/menu/service/MenuService.java
+++ b/src/main/java/com/idukbaduk/itseats/menu/service/MenuService.java
@@ -10,6 +10,7 @@ import com.idukbaduk.itseats.menu.repository.MenuRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -72,7 +73,7 @@ public class MenuService {
                 .orElseThrow(() -> new MenuException(MenuErrorCode.MENU_NOT_FOUND));
     }
 
-    public MenuResponse createMenu(Long storeId, MenuRequest request) {
+    public MenuResponse createMenu(Long storeId, MenuRequest request, List<MultipartFile> imageFiles) {
         MenuGroup menuGroup = findMenuGroup(storeId, request.getMenuGroupName());
         validateDuplicateOptionGroupNames(request.getOptionGroups());
         validateOptionSelectRange(request.getOptionGroups());
@@ -81,12 +82,12 @@ public class MenuService {
         menu.setMenuOptionGroups(createOptionGroups(menu, request.getOptionGroups())); // 옵션 그룹 생성 및 추가
         Menu savedMenu = menuRepository.save(menu); // cascade에 의해 옵션도 모두 저장됨
 
-        List<MenuImage> images = menuMediaService.createMenuImages(savedMenu, request.getImages());
+        List<MenuImage> images = menuMediaService.createMenuImages(savedMenu, imageFiles);
 
         return toResponse(savedMenu, images);
     }
 
-    public MenuResponse updateMenu(Long storeId, Long menuId, MenuRequest request) {
+    public MenuResponse updateMenu(Long storeId, Long menuId, MenuRequest request, List<MultipartFile> imageFiles) {
         Menu menu = menuRepository.findById(menuId).orElseThrow(() -> new MenuException(MenuErrorCode.MENU_NOT_FOUND));
         MenuGroup menuGroup = findMenuGroup(storeId, request.getMenuGroupName());
         validateDuplicateOptionGroupNames(request.getOptionGroups());
@@ -96,7 +97,7 @@ public class MenuService {
         menu.setMenuOptionGroups(createOptionGroups(menu, request.getOptionGroups())); // 옵션 그룹 삭제 후 추가
         Menu savedMenu = menuRepository.save(menu); // cascade에 의해 옵션도 모두 저장됨
 
-        List<MenuImage> images = menuMediaService.updateMenuImages(savedMenu, request.getImages());
+        List<MenuImage> images = menuMediaService.updateMenuImages(savedMenu, imageFiles);
 
         return toResponse(savedMenu, images);
     }

--- a/src/main/java/com/idukbaduk/itseats/menu/service/MenuService.java
+++ b/src/main/java/com/idukbaduk/itseats/menu/service/MenuService.java
@@ -6,21 +6,15 @@ import com.idukbaduk.itseats.menu.entity.enums.MenuStatus;
 import com.idukbaduk.itseats.menu.error.MenuErrorCode;
 import com.idukbaduk.itseats.menu.error.MenuException;
 import com.idukbaduk.itseats.menu.repository.MenuGroupRepository;
-import com.idukbaduk.itseats.menu.repository.MenuOptionGroupRepository;
-import com.idukbaduk.itseats.menu.repository.MenuOptionRepository;
 import com.idukbaduk.itseats.menu.repository.MenuRepository;
-import com.idukbaduk.itseats.store.entity.Store;
-import com.idukbaduk.itseats.store.error.StoreException;
-import com.idukbaduk.itseats.store.error.enums.StoreErrorCode;
-import com.idukbaduk.itseats.store.repository.StoreRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
-import java.util.*;
-import java.util.function.Function;
-import java.util.stream.Collectors;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 
 @Slf4j
 @Service

--- a/src/main/java/com/idukbaduk/itseats/menu/service/MenuService.java
+++ b/src/main/java/com/idukbaduk/itseats/menu/service/MenuService.java
@@ -88,7 +88,9 @@ public class MenuService {
     }
 
     public MenuResponse updateMenu(Long storeId, Long menuId, MenuRequest request, List<MultipartFile> imageFiles) {
-        Menu menu = menuRepository.findById(menuId).orElseThrow(() -> new MenuException(MenuErrorCode.MENU_NOT_FOUND));
+        Menu menu = menuRepository.findByStoreIdAndMenuId(storeId, menuId).orElseThrow(
+                () -> new MenuException(MenuErrorCode.MENU_NOT_FOUND)
+        );
         MenuGroup menuGroup = findMenuGroup(storeId, request.getMenuGroupName());
         validateDuplicateOptionGroupNames(request.getOptionGroups());
         validateOptionSelectRange(request.getOptionGroups());

--- a/src/main/java/com/idukbaduk/itseats/menu/service/UserMenuService.java
+++ b/src/main/java/com/idukbaduk/itseats/menu/service/UserMenuService.java
@@ -1,29 +1,21 @@
 package com.idukbaduk.itseats.menu.service;
 
-import com.idukbaduk.itseats.menu.dto.UserMenuOptionResponse;
-import com.idukbaduk.itseats.menu.dto.UserOptionGroupDto;
-import com.idukbaduk.itseats.menu.dto.UserOptionDto;
-import com.idukbaduk.itseats.menu.entity.*;
-import com.idukbaduk.itseats.menu.error.MenuErrorCode;
-import com.idukbaduk.itseats.menu.error.MenuException;
-import com.idukbaduk.itseats.menu.repository.*;
-import com.idukbaduk.itseats.menu.dto.UserMenuDto;
-import com.idukbaduk.itseats.menu.dto.UserMenuGroupDto;
-import com.idukbaduk.itseats.menu.dto.UserMenuListResponse;
+import com.idukbaduk.itseats.menu.dto.*;
 import com.idukbaduk.itseats.menu.entity.Menu;
 import com.idukbaduk.itseats.menu.entity.MenuGroup;
 import com.idukbaduk.itseats.menu.entity.MenuImage;
+import com.idukbaduk.itseats.menu.entity.MenuOptionGroup;
 import com.idukbaduk.itseats.menu.error.MenuErrorCode;
 import com.idukbaduk.itseats.menu.error.MenuException;
-
-
+import com.idukbaduk.itseats.menu.repository.MenuGroupRepository;
+import com.idukbaduk.itseats.menu.repository.MenuImageRepository;
+import com.idukbaduk.itseats.menu.repository.MenuOptionGroupRepository;
+import com.idukbaduk.itseats.menu.repository.MenuRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.*;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 @Service
 @RequiredArgsConstructor

--- a/src/test/java/com/idukbaduk/itseats/menu/controller/MenuControllerTest.java
+++ b/src/test/java/com/idukbaduk/itseats/menu/controller/MenuControllerTest.java
@@ -7,7 +7,6 @@ import com.idukbaduk.itseats.menu.dto.MenuGroupResponse;
 import com.idukbaduk.itseats.menu.dto.MenuResponse;
 import com.idukbaduk.itseats.menu.service.MenuGroupService;
 import com.idukbaduk.itseats.menu.service.MenuService;
-import com.idukbaduk.itseats.store.dto.enums.StoreResponse;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -15,7 +14,6 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
-import org.springframework.security.web.util.matcher.RequestMatchers;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 

--- a/src/test/java/com/idukbaduk/itseats/menu/controller/MenuControllerTest.java
+++ b/src/test/java/com/idukbaduk/itseats/menu/controller/MenuControllerTest.java
@@ -15,6 +15,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.security.web.util.matcher.RequestMatchers;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -27,6 +28,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -95,6 +97,69 @@ class MenuControllerTest {
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.status").value(400))
                 .andExpect(jsonPath("$.message").value("메뉴 이름은 필수입니다."));
+    }
+
+    @DisplayName("메뉴 수정 성공")
+    @Test
+    void updateMenu_success() throws Exception {
+        // given
+        MenuResponse response = MenuResponse.builder()
+                .menuId(1L)
+                .menuName("카페라떼")
+                .menuPrice(3000L)
+                .menuGroupName("음료")
+                .images(List.of("s3 link"))
+                .build();
+        when(menuService.updateMenu(anyLong(), anyLong(), any())).thenReturn(response);
+
+        MockMultipartFile imageFile = new MockMultipartFile(
+                "images", "test.jpg", "image/jpeg", "test image content".getBytes());
+
+        // when & then
+        mockMvc.perform(multipart("/api/owner/1/menus/1")
+                        .file(imageFile)
+                        .param("menuName", "카페라떼")
+                        .param("menuDescription", "평범한 카페라떼입니다.")
+                        .param("menuPrice", "3000")
+                        .param("menuStatus", "HIDDEN")
+                        .param("menuGroupName", "음료")
+                        .param("menuPriority", "1")
+                        .with(request -> {
+                            request.setMethod("PUT");
+                            return request;
+                        })
+                        .contentType(MediaType.MULTIPART_FORM_DATA)
+                        .accept(MediaType.APPLICATION_JSON)
+                        .characterEncoding("UTF-8"))
+                .andExpect(status().isOk())
+                .andDo(print())
+                .andExpect(jsonPath("$.httpStatus").value(200))
+                .andExpect(jsonPath("$.message").value(UPDATE_MENU_SUCCESS.getMessage()))
+                .andExpect(jsonPath("$.data.menuId").value("1"))
+                .andExpect(jsonPath("$.data.menuName").value("카페라떼"));
+    }
+
+    @DisplayName("메뉴 수정 요청 검증 실패 - 가격이 음수")
+    @Test
+    void updateMenu_notValid() throws Exception {
+        // when & then
+        mockMvc.perform(multipart("/api/owner/1/menus/1")
+                        .param("menuName", "카페라떼")
+                        .param("menuDescription", "평범한 카페라떼입니다.")
+                        .param("menuPrice", "-3000")
+                        .param("menuStatus", "ON_SALE")
+                        .param("menuGroupName", "음료")
+                        .param("menuPriority", "1")
+                        .with(request -> {
+                            request.setMethod("PUT");
+                            return request;
+                        })
+                        .contentType(MediaType.MULTIPART_FORM_DATA)
+                        .accept(MediaType.APPLICATION_JSON)
+                        .characterEncoding("UTF-8"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.status").value(400))
+                .andExpect(jsonPath("$.message").value("메뉴 가격은 0원 이상이어야 합니다."));
     }
 
     @DisplayName("메뉴 그룹 조회 성공")

--- a/src/test/java/com/idukbaduk/itseats/menu/controller/MenuControllerTest.java
+++ b/src/test/java/com/idukbaduk/itseats/menu/controller/MenuControllerTest.java
@@ -17,6 +17,7 @@ import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -55,23 +56,32 @@ class MenuControllerTest {
                 .menuGroupName("음료")
                 .images(List.of("s3 link"))
                 .build();
-        when(menuService.createMenu(anyLong(), any())).thenReturn(response);
+        when(menuService.createMenu(anyLong(), any(), any())).thenReturn(response);
+
+        String requestJson = """
+            {
+                "menuName": "아메리카노",
+                "menuDescription": "평범한 아메리카노입니다.",
+                "menuPrice": 2000,
+                "menuStatus": "ON_SALE",
+                "menuGroupName": "음료",
+                "menuPriority": 1
+            }
+        """;
+        MockMultipartFile requestPart = new MockMultipartFile(
+                "request", "request.json", "application/json", requestJson.getBytes(StandardCharsets.UTF_8)
+        );
 
         MockMultipartFile imageFile = new MockMultipartFile(
                 "images", "test.jpg", "image/jpeg", "test image content".getBytes());
 
         // when & then
         mockMvc.perform(multipart("/api/owner/1/menus/new")
-                .file(imageFile)
-                .param("menuName", "아메리카노")
-                .param("menuDescription", "평범한 아메리카노입니다.")
-                .param("menuPrice", "2000")
-                .param("menuStatus", "ON_SALE")
-                .param("menuGroupName", "음료")
-                .param("menuPriority", "1")
-                .contentType(MediaType.MULTIPART_FORM_DATA)
-                .accept(MediaType.APPLICATION_JSON)
-                .characterEncoding("UTF-8"))
+                        .file(requestPart)
+                        .file(imageFile)
+                        .contentType(MediaType.MULTIPART_FORM_DATA)
+                        .accept(MediaType.APPLICATION_JSON)
+                        .characterEncoding("UTF-8"))
                 .andExpect(status().isCreated())
                 .andExpect(jsonPath("$.httpStatus").value(201))
                 .andExpect(jsonPath("$.message").value(CREATE_MENU_SUCCESS.getMessage()))
@@ -82,13 +92,23 @@ class MenuControllerTest {
     @DisplayName("메뉴 추가 요청 검증 실패 - 메뉴 이름 없음")
     @Test
     void createMenu_notValid() throws Exception {
+        // given
+        String requestJson = """
+            {
+                "menuDescription": "평범한 아메리카노입니다.",
+                "menuPrice": 2000,
+                "menuStatus": "ON_SALE",
+                "menuGroupName": "음료",
+                "menuPriority": 1
+            }
+        """;
+        MockMultipartFile requestPart = new MockMultipartFile(
+                "request", "request.json", "application/json", requestJson.getBytes(StandardCharsets.UTF_8)
+        );
+
         // when & then
         mockMvc.perform(multipart("/api/owner/1/menus/new")
-                        .param("menuDescription", "평범한 아메리카노입니다.")
-                        .param("menuPrice", "2000")
-                        .param("menuStatus", "ON_SALE")
-                        .param("menuGroupName", "음료")
-                        .param("menuPriority", "1")
+                        .file(requestPart)
                         .contentType(MediaType.MULTIPART_FORM_DATA)
                         .accept(MediaType.APPLICATION_JSON)
                         .characterEncoding("UTF-8"))
@@ -108,20 +128,29 @@ class MenuControllerTest {
                 .menuGroupName("음료")
                 .images(List.of("s3 link"))
                 .build();
-        when(menuService.updateMenu(anyLong(), anyLong(), any())).thenReturn(response);
+        when(menuService.updateMenu(anyLong(), anyLong(), any(), any())).thenReturn(response);
+
+        String requestJson = """
+            {
+                "menuName": "카페라떼",
+                "menuDescription": "평범한 카페라떼입니다.",
+                "menuPrice": 3000,
+                "menuStatus": "HIDDEN",
+                "menuGroupName": "음료",
+                "menuPriority": 1
+            }
+        """;
+        MockMultipartFile requestPart = new MockMultipartFile(
+                "request", "request.json", "application/json", requestJson.getBytes(StandardCharsets.UTF_8)
+        );
 
         MockMultipartFile imageFile = new MockMultipartFile(
                 "images", "test.jpg", "image/jpeg", "test image content".getBytes());
 
         // when & then
         mockMvc.perform(multipart("/api/owner/1/menus/1")
+                        .file(requestPart)
                         .file(imageFile)
-                        .param("menuName", "카페라떼")
-                        .param("menuDescription", "평범한 카페라떼입니다.")
-                        .param("menuPrice", "3000")
-                        .param("menuStatus", "HIDDEN")
-                        .param("menuGroupName", "음료")
-                        .param("menuPriority", "1")
                         .with(request -> {
                             request.setMethod("PUT");
                             return request;
@@ -141,13 +170,22 @@ class MenuControllerTest {
     @Test
     void updateMenu_notValid() throws Exception {
         // when & then
+        String requestJson = """
+        {
+            "menuName": "카페라떼",
+            "menuDescription": "평범한 카페라떼입니다.",
+            "menuPrice": -3000,
+            "menuStatus": "ON_SALE",
+            "menuGroupName": "음료",
+            "menuPriority": 1
+        }
+        """;
+        MockMultipartFile requestPart = new MockMultipartFile(
+                "request", "request.json", "application/json", requestJson.getBytes(StandardCharsets.UTF_8)
+        );
+
         mockMvc.perform(multipart("/api/owner/1/menus/1")
-                        .param("menuName", "카페라떼")
-                        .param("menuDescription", "평범한 카페라떼입니다.")
-                        .param("menuPrice", "-3000")
-                        .param("menuStatus", "ON_SALE")
-                        .param("menuGroupName", "음료")
-                        .param("menuPriority", "1")
+                        .file(requestPart)
                         .with(request -> {
                             request.setMethod("PUT");
                             return request;

--- a/src/test/java/com/idukbaduk/itseats/menu/service/MenuServiceTest.java
+++ b/src/test/java/com/idukbaduk/itseats/menu/service/MenuServiceTest.java
@@ -151,7 +151,6 @@ class MenuServiceTest {
                 .menuStatus(MenuStatus.ON_SALE)
                 .menuGroupName("음료")
                 .menuPriority(1)
-                .images(List.of(imageFile))
                 .optionGroups(List.of(
                         MenuOptionGroupDto.builder()
                                 .optionGroupName("샷 추가")
@@ -178,7 +177,7 @@ class MenuServiceTest {
         ));
 
         // when
-        MenuResponse data = menuService.createMenu(storeId, request);
+        MenuResponse data = menuService.createMenu(storeId, request, List.of(imageFile));
 
         // then
         assertThat(data).isNotNull()
@@ -203,7 +202,7 @@ class MenuServiceTest {
                 .build();
 
         // when & then
-        assertThatThrownBy(() -> menuService.createMenu(storeId, menuRequest))
+        assertThatThrownBy(() -> menuService.createMenu(storeId, menuRequest, Collections.emptyList()))
                 .isInstanceOf(MenuException.class)
                 .hasMessageContaining(MenuErrorCode.MENU_GROUP_NOT_FOUND.getMessage());
     }
@@ -224,7 +223,7 @@ class MenuServiceTest {
                 .build();
 
         // when & then
-        assertThatThrownBy(() -> menuService.createMenu(storeId, menuRequest))
+        assertThatThrownBy(() -> menuService.createMenu(storeId, menuRequest, Collections.emptyList()))
                 .isInstanceOf(MenuException.class)
                 .hasMessageContaining(MenuErrorCode.OPTION_GROUP_NAME_DUPLICATED.getMessage());
     }
@@ -244,7 +243,7 @@ class MenuServiceTest {
                 .build();
 
         // when & then
-        assertThatThrownBy(() -> menuService.createMenu(storeId, menuRequest))
+        assertThatThrownBy(() -> menuService.createMenu(storeId, menuRequest, Collections.emptyList()))
                 .isInstanceOf(MenuException.class)
                 .hasMessageContaining(MenuErrorCode.OPTION_GROUP_RANGE_INVALID.getMessage());
     }
@@ -283,7 +282,6 @@ class MenuServiceTest {
                 .menuPrice(3000L)
                 .menuStatus(MenuStatus.HIDDEN)
                 .menuGroupName("음료")
-                .images(List.of(imageFile))
                 .optionGroups(List.of(
                         MenuOptionGroupDto.builder()
                                 .optionGroupName("샷 추가")
@@ -310,7 +308,7 @@ class MenuServiceTest {
         ));
 
         // when
-        MenuResponse data = menuService.updateMenu(storeId, menuId, request);
+        MenuResponse data = menuService.updateMenu(storeId, menuId, request, List.of(imageFile));
 
         // then
         assertThat(data).isNotNull()
@@ -337,7 +335,7 @@ class MenuServiceTest {
                 .build();
 
         // when & then
-        assertThatThrownBy(() -> menuService.updateMenu(storeId, menuId, menuRequest))
+        assertThatThrownBy(() -> menuService.updateMenu(storeId, menuId, menuRequest, Collections.emptyList()))
                 .isInstanceOf(MenuException.class)
                 .hasMessageContaining(MenuErrorCode.MENU_NOT_FOUND.getMessage());
     }
@@ -357,7 +355,7 @@ class MenuServiceTest {
                 .build();
 
         // when & then
-        assertThatThrownBy(() -> menuService.updateMenu(storeId, menuId, menuRequest))
+        assertThatThrownBy(() -> menuService.updateMenu(storeId, menuId, menuRequest, Collections.emptyList()))
                 .isInstanceOf(MenuException.class)
                 .hasMessageContaining(MenuErrorCode.MENU_GROUP_NOT_FOUND.getMessage());
     }
@@ -382,7 +380,7 @@ class MenuServiceTest {
                 .build();
 
         // when & then
-        assertThatThrownBy(() -> menuService.updateMenu(storeId, menuId, menuRequest))
+        assertThatThrownBy(() -> menuService.updateMenu(storeId, menuId, menuRequest, Collections.emptyList()))
                 .isInstanceOf(MenuException.class)
                 .hasMessageContaining(MenuErrorCode.OPTION_GROUP_NAME_DUPLICATED.getMessage());
     }
@@ -406,7 +404,7 @@ class MenuServiceTest {
                 .build();
 
         // when & then
-        assertThatThrownBy(() -> menuService.updateMenu(storeId, menuId, menuRequest))
+        assertThatThrownBy(() -> menuService.updateMenu(storeId, menuId, menuRequest, Collections.emptyList()))
                 .isInstanceOf(MenuException.class)
                 .hasMessageContaining(MenuErrorCode.OPTION_GROUP_RANGE_INVALID.getMessage());
     }

--- a/src/test/java/com/idukbaduk/itseats/menu/service/MenuServiceTest.java
+++ b/src/test/java/com/idukbaduk/itseats/menu/service/MenuServiceTest.java
@@ -272,7 +272,7 @@ class MenuServiceTest {
                 .menuOptionGroups(new ArrayList<>(List.of(optionGroup)))
                 .build();
 
-        when(menuRepository.findById(menuId)).thenReturn(Optional.of(menu));
+        when(menuRepository.findByStoreIdAndMenuId(storeId, menuId)).thenReturn(Optional.of(menu));
 
         MockMultipartFile imageFile = new MockMultipartFile(
                 "images", "test.jpg", "image/jpeg", "test image content".getBytes());
@@ -329,7 +329,7 @@ class MenuServiceTest {
         // given
         Long storeId = 1L;
         Long menuId = 1L;
-        when(menuRepository.findById(menuId))
+        when(menuRepository.findByStoreIdAndMenuId(storeId, menuId))
                 .thenReturn(Optional.empty());
         MenuRequest menuRequest = MenuRequest.builder()
                 .build();
@@ -346,7 +346,7 @@ class MenuServiceTest {
         // given
         Long storeId = 1L;
         Long menuId = 1L;
-        when(menuRepository.findById(menuId))
+        when(menuRepository.findByStoreIdAndMenuId(storeId, menuId))
                 .thenReturn(Optional.of(Menu.builder().build()));
         when(menuGroupRepository.findMenuGroupByMenuGroupNameAndStore_StoreId(any(), any()))
                 .thenReturn(Optional.empty());
@@ -366,7 +366,7 @@ class MenuServiceTest {
         // given
         Long storeId = 1L;
         Long menuId = 1L;
-        when(menuRepository.findById(menuId))
+        when(menuRepository.findByStoreIdAndMenuId(storeId, menuId))
                 .thenReturn(Optional.of(Menu.builder().build()));
         when(menuGroupRepository.findMenuGroupByMenuGroupNameAndStore_StoreId(any(), any()))
                 .thenReturn(Optional.of(MenuGroup.builder().menuGroupName("그룹").build()));
@@ -391,7 +391,7 @@ class MenuServiceTest {
         // given
         Long storeId = 1L;
         Long menuId = 1L;
-        when(menuRepository.findById(menuId))
+        when(menuRepository.findByStoreIdAndMenuId(storeId, menuId))
                 .thenReturn(Optional.of(Menu.builder().build()));
         when(menuGroupRepository.findMenuGroupByMenuGroupNameAndStore_StoreId(any(), any()))
                 .thenReturn(Optional.of(MenuGroup.builder().menuGroupName("그룹").build()));


### PR DESCRIPTION
## #️⃣연관된 이슈

#116 
closes #116

## 📝작업 내용

메뉴를 수정하는 API를 구현하였습니다.
또한 요청 body를 @RequestPart로 매핑하도록 변경하였습니다.

- [x] Entity 및 DTO 확인
- [x] Repository 구현
- [x] Service 구현
- [x] Controller 구현
- [x] 컨트롤러 및 서비스 테스트 코드 작성

### 스크린샷 (선택)

<details>
    <summary>열기</summary>

![메뉴 수정 성공](https://github.com/user-attachments/assets/da6006ad-7e82-4ee8-b161-bc82e098e3e5)
![메뉴 서비스 테스트](https://github.com/user-attachments/assets/4226de00-2215-4688-a19c-516de5573ce3)
![컨트롤러 테스트](https://github.com/user-attachments/assets/d4074f91-7b65-4604-b9eb-b0d742f176ea)

</details>

## 💬리뷰 요구사항(선택)

`Menu` entity 클래스에 setter를 안 쓴다고 한번에 여러 필드를 업데이트하는 함수를 아래처럼 만들었는데 이렇게 만드는게 맞을까요?
```
    public void updateMenu(MenuGroup menuGroup, String menuName, Long menuPrice,
                           MenuStatus menuStatus, String menuDescription, int menuPriority) {
        this.menuGroup = menuGroup;
        this.menuName = menuName;
        this.menuPrice = menuPrice;
        this.menuStatus = menuStatus;
        this.menuDescription = menuDescription;
        this.menuPriority = menuPriority;
    }
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 메뉴 수정 기능이 추가되어, 메뉴 정보와 이미지를 함께 수정할 수 있습니다.
- **기능 개선**
  - 메뉴 생성 및 수정 시 이미지 파일을 별도로 첨부할 수 있도록 개선되었습니다.
  - 메뉴 옵션 그룹 및 옵션 관리 방식이 개선되어, 옵션 그룹 일괄 수정이 가능합니다.
  - 메뉴 이미지 업데이트 시 기존 이미지 유지, 삭제 및 신규 이미지 저장이 명확히 처리됩니다.
- **버그 수정**
  - 메뉴 생성 및 수정 시 유효하지 않은 이미지 파일이 무시됩니다.
- **테스트**
  - 메뉴 수정 및 이미지 첨부 관련 테스트가 추가되어 안정성이 향상되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->