### PR TITLE
[Feature] 가맹점 메뉴 상세 조회 API 구현

### DIFF
--- a/src/main/java/com/idukbaduk/itseats/menu/controller/MenuController.java
+++ b/src/main/java/com/idukbaduk/itseats/menu/controller/MenuController.java
@@ -60,4 +60,13 @@ public class MenuController {
         MenuGroupResponse data = menuGroupService.getMenuGroup(storeId);
         return BaseResponse.toResponseEntity(MenuResponse.GET_MENU_GROUP_SUCCESS, data);
     }
+
+    @GetMapping("/{storeId}/menus/{menuId}")
+    public ResponseEntity<BaseResponse> getMenuDetail(
+            @PathVariable("storeId") Long storeId,
+            @PathVariable("menuId") Long menuId
+    ) {
+        MenuDetailResponse data = menuService.getMenuDetail(storeId, menuId);
+        return BaseResponse.toResponseEntity(MenuResponse.GET_MENU_DETAIL_SUCCESS, data);
+    }
 }

--- a/src/main/java/com/idukbaduk/itseats/menu/dto/MenuDetailResponse.java
+++ b/src/main/java/com/idukbaduk/itseats/menu/dto/MenuDetailResponse.java
@@ -1,0 +1,19 @@
+package com.idukbaduk.itseats.menu.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class MenuDetailResponse {
+    private Long menuId;
+    private String menuName;
+    private String menuDescription;
+    private Long menuPrice;
+    private String menuStatus;
+    private Float menuRating;
+    private String menuGroupName;
+    private List<MenuOptionGroupDto> optionGroups;
+}

--- a/src/main/java/com/idukbaduk/itseats/menu/dto/enums/MenuResponse.java
+++ b/src/main/java/com/idukbaduk/itseats/menu/dto/enums/MenuResponse.java
@@ -10,7 +10,8 @@ public enum MenuResponse implements Response {
     GET_MENU_LIST_SUCCESS(HttpStatus.OK, "메뉴 목록 조회 성공"),
     GET_MENU_GROUP_SUCCESS(HttpStatus.OK, "메뉴 그룹 조회 성공"),
     SAVE_MENU_GROUP_SUCCESS(HttpStatus.OK, "메뉴 그룹 설정 성공"),
-    CREATE_MENU_SUCCESS(HttpStatus.CREATED, "메뉴 추가 성공")
+    CREATE_MENU_SUCCESS(HttpStatus.CREATED, "메뉴 추가 성공"),
+    GET_MENU_DETAIL_SUCCESS(HttpStatus.OK, "메뉴 상세 조회 성공")
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/idukbaduk/itseats/menu/error/MenuErrorCode.java
+++ b/src/main/java/com/idukbaduk/itseats/menu/error/MenuErrorCode.java
@@ -13,6 +13,7 @@ public enum MenuErrorCode implements ErrorCode {
     MENU_GROUP_NOT_FOUND(HttpStatus.NOT_FOUND, "메뉴 그룹을 찾을 수 없습니다."),
     OPTION_GROUP_NAME_DUPLICATED(HttpStatus.BAD_REQUEST, "옵션 그룹 이름은 중복될 수 없습니다."),
     OPTION_GROUP_RANGE_INVALID(HttpStatus.BAD_REQUEST, "옵션 그룹 최대 선택은 최소 선택 이상이어야 합니다."),
+    MENU_ACCESS_DENIED(HttpStatus.FORBIDDEN, "해당 메뉴에 접근할 권한이 없습니다.")
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/idukbaduk/itseats/menu/repository/MenuRepository.java
+++ b/src/main/java/com/idukbaduk/itseats/menu/repository/MenuRepository.java
@@ -30,6 +30,6 @@ public interface MenuRepository extends JpaRepository<Menu, Long> {
             "JOIN FETCH m.menuGroup mg " +
             "LEFT JOIN FETCH m.menuOptionGroups mog " +
             "LEFT JOIN FETCH mog.options o " +
-            "WHERE m.menuId = :menuId")
+            "WHERE m.menuId = :menuId AND m.deleted = false ")
     Optional<Menu> findDetailById(@Param("menuId") Long menuId);
 }

--- a/src/main/java/com/idukbaduk/itseats/menu/repository/MenuRepository.java
+++ b/src/main/java/com/idukbaduk/itseats/menu/repository/MenuRepository.java
@@ -25,4 +25,11 @@ public interface MenuRepository extends JpaRepository<Menu, Long> {
     Optional<Menu> findByMenuIdAndDeletedFalse(Long menuId);
 
     boolean existsByMenuGroup(MenuGroup menuGroup);
+
+    @Query("SELECT m FROM Menu m " +
+            "JOIN FETCH m.menuGroup mg " +
+            "LEFT JOIN FETCH m.menuOptionGroups mog " +
+            "LEFT JOIN FETCH mog.options o " +
+            "WHERE m.menuId = :menuId")
+    Optional<Menu> findDetailById(@Param("menuId") Long menuId);
 }

--- a/src/main/java/com/idukbaduk/itseats/menu/service/MenuService.java
+++ b/src/main/java/com/idukbaduk/itseats/menu/service/MenuService.java
@@ -67,6 +67,23 @@ public class MenuService {
                 .build();
     }
 
+    public MenuDetailResponse getMenuDetail(Long storeId, Long menuId) {
+        Menu menu = menuRepository.findDetailById(menuId)
+                .orElseThrow(() -> new MenuException(MenuErrorCode.MENU_NOT_FOUND));
+
+        return MenuDetailResponse.builder()
+                .menuId(menu.getMenuId())
+                .menuName(menu.getMenuName())
+                .menuDescription(menu.getMenuDescription())
+                .menuPrice(menu.getMenuPrice())
+                .menuStatus(menu.getMenuStatus().name())
+                .menuRating(menu.getMenuRating())
+                .menuGroupName(menu.getMenuGroup().getMenuGroupName())
+                .optionGroups(optionGroupsToDto(menu.getMenuOptionGroups()))
+                .build();
+    }
+
+
     private int getMenuCount(List<Menu> menus, MenuStatus menuStatus) {
         return (int) menus.stream()
                 .filter(m -> m.getMenuStatus() == menuStatus)

--- a/src/main/java/com/idukbaduk/itseats/menu/service/MenuService.java
+++ b/src/main/java/com/idukbaduk/itseats/menu/service/MenuService.java
@@ -71,6 +71,10 @@ public class MenuService {
         Menu menu = menuRepository.findDetailById(menuId)
                 .orElseThrow(() -> new MenuException(MenuErrorCode.MENU_NOT_FOUND));
 
+        if (!menu.getMenuGroup().getStore().getStoreId().equals(storeId)) {
+            throw new MenuException(MenuErrorCode.MENU_ACCESS_DENIED);
+        }
+
         return MenuDetailResponse.builder()
                 .menuId(menu.getMenuId())
                 .menuName(menu.getMenuName())

--- a/src/test/java/com/idukbaduk/itseats/menu/controller/MenuDetailControllerTest.java
+++ b/src/test/java/com/idukbaduk/itseats/menu/controller/MenuDetailControllerTest.java
@@ -1,0 +1,119 @@
+package com.idukbaduk.itseats.menu.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.idukbaduk.itseats.global.response.BaseResponse;
+import com.idukbaduk.itseats.menu.controller.MenuController;
+import com.idukbaduk.itseats.menu.dto.MenuDetailResponse;
+import com.idukbaduk.itseats.menu.dto.MenuOptionDto;
+import com.idukbaduk.itseats.menu.dto.MenuOptionGroupDto;
+import com.idukbaduk.itseats.menu.dto.enums.MenuResponse;
+import com.idukbaduk.itseats.menu.error.MenuErrorCode;
+import com.idukbaduk.itseats.menu.error.MenuException;
+import com.idukbaduk.itseats.menu.service.MenuGroupService;
+import com.idukbaduk.itseats.menu.service.MenuService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.BDDMockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
+import static org.mockito.BDDMockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(MenuController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class MenuDetailControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private MenuService menuService;
+
+    @MockitoBean
+    private MenuGroupService menuGroupService;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    @DisplayName("메뉴 상세 조회 성공 응답")
+    void getMenuDetail_success() throws Exception {
+        // given
+        Long storeId = 1L;
+        Long menuId = 11L;
+        MenuOptionDto optionDto = MenuOptionDto.builder()
+                .optionName("톨(Tall)")
+                .optionPrice(0L)
+                .optionStatus(com.idukbaduk.itseats.menu.entity.enums.MenuStatus.ON_SALE)
+                .optionPriority(1)
+                .build();
+        MenuOptionGroupDto groupDto = MenuOptionGroupDto.builder()
+                .optionGroupName("사이즈")
+                .isRequired(true)
+                .minSelect(1)
+                .maxSelect(1)
+                .priority(1)
+                .options(List.of(optionDto))
+                .build();
+        MenuDetailResponse response = MenuDetailResponse.builder()
+                .menuId(menuId)
+                .menuName("아메리카노")
+                .menuDescription("평범한 아메리카노입니다.")
+                .menuPrice(2000L)
+                .menuStatus("ON_SALE")
+                .menuRating(4.43f)
+                .menuGroupName("음료")
+                .optionGroups(List.of(groupDto))
+                .build();
+
+        given(menuService.getMenuDetail(storeId, menuId)).willReturn(response);
+
+        // when & then
+        mockMvc.perform(get("/api/owner/{storeId}/menus/{menuId}", storeId, menuId)
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.httpStatus").value(MenuResponse.GET_MENU_DETAIL_SUCCESS.getHttpStatus().value()))
+                .andExpect(jsonPath("$.message").value(MenuResponse.GET_MENU_DETAIL_SUCCESS.getMessage()))
+                .andExpect(jsonPath("$.data.menuId").value(menuId))
+                .andExpect(jsonPath("$.data.menuName").value("아메리카노"))
+                .andExpect(jsonPath("$.data.menuDescription").value("평범한 아메리카노입니다."))
+                .andExpect(jsonPath("$.data.menuPrice").value(2000))
+                .andExpect(jsonPath("$.data.menuStatus").value("ON_SALE"))
+                .andExpect(jsonPath("$.data.menuRating").value(4.43f))
+                .andExpect(jsonPath("$.data.menuGroupName").value("음료"))
+                .andExpect(jsonPath("$.data.optionGroups[0].optionGroupName").value("사이즈"))
+                .andExpect(jsonPath("$.data.optionGroups[0].required").value(true))
+                .andExpect(jsonPath("$.data.optionGroups[0].minSelect").value(1))
+                .andExpect(jsonPath("$.data.optionGroups[0].maxSelect").value(1))
+                .andExpect(jsonPath("$.data.optionGroups[0].priority").value(1))
+                .andExpect(jsonPath("$.data.optionGroups[0].options[0].optionName").value("톨(Tall)"))
+                .andExpect(jsonPath("$.data.optionGroups[0].options[0].optionPrice").value(0))
+                .andExpect(jsonPath("$.data.optionGroups[0].options[0].optionStatus").value("ON_SALE"))
+                .andExpect(jsonPath("$.data.optionGroups[0].options[0].optionPriority").value(1));
+    }
+
+    @Test
+    @DisplayName("메뉴가 없으면 404 에러 응답")
+    void getMenuDetail_menuNotFound() throws Exception {
+        // given
+        Long storeId = 1L;
+        Long menuId = 999L;
+        given(menuService.getMenuDetail(storeId, menuId))
+                .willThrow(new MenuException(MenuErrorCode.MENU_NOT_FOUND));
+
+        // when & then
+        mockMvc.perform(get("/api/owner/{storeId}/menus/{menuId}", storeId, menuId)
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.status").value(MenuErrorCode.MENU_NOT_FOUND.getHttpStatus().value()))
+                .andExpect(jsonPath("$.message").value(MenuErrorCode.MENU_NOT_FOUND.getMessage()));
+    }
+}

--- a/src/test/java/com/idukbaduk/itseats/menu/service/MenuDetailServiceTest.java
+++ b/src/test/java/com/idukbaduk/itseats/menu/service/MenuDetailServiceTest.java
@@ -1,0 +1,106 @@
+package com.idukbaduk.itseats.menu.service;
+
+import com.idukbaduk.itseats.menu.dto.MenuDetailResponse;
+import com.idukbaduk.itseats.menu.dto.MenuOptionDto;
+import com.idukbaduk.itseats.menu.dto.MenuOptionGroupDto;
+import com.idukbaduk.itseats.menu.entity.*;
+import com.idukbaduk.itseats.menu.entity.enums.MenuStatus;
+import com.idukbaduk.itseats.menu.error.MenuException;
+import com.idukbaduk.itseats.menu.error.MenuErrorCode;
+import com.idukbaduk.itseats.menu.repository.MenuRepository;
+
+import com.idukbaduk.itseats.store.entity.Store;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class MenuDetailServiceTest {
+
+    @Mock
+    private MenuRepository menuRepository;
+
+    @InjectMocks
+    private MenuService menuService;
+
+    @Test
+    @DisplayName("메뉴 상세 조회 성공")
+    void getMenuDetail_success() {
+        // given
+        Long storeId = 1L;
+        Long menuId = 11L;
+
+        Store store = Store.builder().storeId(storeId).build();
+        MenuGroup menuGroup = MenuGroup.builder().menuGroupId(1L).menuGroupName("음료").store(store).build();
+        MenuOption option1 = MenuOption.builder()
+                .optionId(1L).optionName("톨(Tall)").optionPrice(0L).optionStatus(MenuStatus.ON_SALE).optionPriority(1)
+                .build();
+        MenuOption option2 = MenuOption.builder()
+                .optionId(2L).optionName("벤티(Venti)").optionPrice(1000L).optionStatus(MenuStatus.HIDDEN).optionPriority(2)
+                .build();
+        MenuOptionGroup group = MenuOptionGroup.builder()
+                .optGroupId(1L).optGroupName("사이즈").isRequired(true).minSelect(1).maxSelect(1).optGroupPriority(1)
+                .options(List.of(option1, option2))
+                .build();
+        Menu menu = Menu.builder()
+                .menuId(menuId)
+                .menuName("아메리카노")
+                .menuDescription("평범한 아메리카노입니다.")
+                .menuPrice(2000L)
+                .menuStatus(MenuStatus.ON_SALE)
+                .menuRating(4.43f)
+                .menuGroup(menuGroup)
+                .menuOptionGroups(List.of(group))
+                .build();
+
+        given(menuRepository.findDetailById(menuId)).willReturn(Optional.of(menu));
+
+        // when
+        MenuDetailResponse response = menuService.getMenuDetail(storeId, menuId);
+
+        // then
+        assertThat(response.getMenuId()).isEqualTo(menuId);
+        assertThat(response.getMenuName()).isEqualTo("아메리카노");
+        assertThat(response.getMenuDescription()).isEqualTo("평범한 아메리카노입니다.");
+        assertThat(response.getMenuPrice()).isEqualTo(2000L);
+        assertThat(response.getMenuStatus()).isEqualTo("ON_SALE");
+        assertThat(response.getMenuRating()).isEqualTo(4.43f);
+        assertThat(response.getMenuGroupName()).isEqualTo("음료");
+        assertThat(response.getOptionGroups()).hasSize(1);
+        MenuOptionGroupDto groupDto = response.getOptionGroups().get(0);
+        assertThat(groupDto.getOptionGroupName()).isEqualTo("사이즈");
+        assertThat(groupDto.isRequired()).isTrue();
+        assertThat(groupDto.getMinSelect()).isEqualTo(1);
+        assertThat(groupDto.getMaxSelect()).isEqualTo(1);
+        assertThat(groupDto.getPriority()).isEqualTo(1);
+        assertThat(groupDto.getOptions()).hasSize(2);
+        MenuOptionDto opt1 = groupDto.getOptions().get(0);
+        assertThat(opt1.getOptionName()).isEqualTo("톨(Tall)");
+        assertThat(opt1.getOptionPrice()).isEqualTo(0L);
+        assertThat(opt1.getOptionStatus()).isEqualTo(MenuStatus.ON_SALE);
+        assertThat(opt1.getOptionPriority()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("메뉴가 없으면 예외 발생")
+    void getMenuDetail_menuNotFound() {
+        // given
+        Long storeId = 1L;
+        Long menuId = 999L;
+        given(menuRepository.findDetailById(menuId)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> menuService.getMenuDetail(storeId, menuId))
+                .isInstanceOf(MenuException.class)
+                .hasMessage(MenuErrorCode.MENU_NOT_FOUND.getMessage());
+    }
+}

--- a/src/test/java/com/idukbaduk/itseats/menu/service/MenuDetailServiceTest.java
+++ b/src/test/java/com/idukbaduk/itseats/menu/service/MenuDetailServiceTest.java
@@ -88,6 +88,11 @@ class MenuDetailServiceTest {
         assertThat(opt1.getOptionPrice()).isEqualTo(0L);
         assertThat(opt1.getOptionStatus()).isEqualTo(MenuStatus.ON_SALE);
         assertThat(opt1.getOptionPriority()).isEqualTo(1);
+        MenuOptionDto opt2 = groupDto.getOptions().get(1);
+        assertThat(opt2.getOptionName()).isEqualTo("벤티(Venti)");
+        assertThat(opt2.getOptionPrice()).isEqualTo(1000L);
+        assertThat(opt2.getOptionStatus()).isEqualTo(MenuStatus.HIDDEN);
+        assertThat(opt2.getOptionPriority()).isEqualTo(2);
     }
 
     @Test


### PR DESCRIPTION
## #️⃣연관된 이슈

#52 
## 📝작업 내용

- [ ] DTO - `MenuDetailResponse`추가
- [ ] `MenuRepository`추가
- [ ] `MenuService`, `MenuController`에 상세 조회 관련 메서드 추가
- [ ] 테스트 코드 작성 후 작동 확인 완료 

### 스크린샷 (선택)
<img width="423" alt="image" src="https://github.com/user-attachments/assets/c08f4b5c-9f9a-4351-9533-37e5ac1a55d8" />
<img width="423" alt="image" src="https://github.com/user-attachments/assets/ddc24506-8063-49e1-8d85-1fda7c20270c" />



## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 매장별 특정 메뉴의 상세 정보를 조회할 수 있는 API 엔드포인트가 추가되었습니다.
  * 메뉴 상세 정보에 메뉴명, 설명, 가격, 상태, 평점, 그룹명 및 옵션 그룹 정보가 포함됩니다.
  * 메뉴 접근 권한이 없는 경우에 대한 권한 오류가 추가되었습니다.

* **버그 수정**
  * 메뉴 상세 조회 시 메뉴가 존재하지 않을 경우 404 오류 응답이 반환됩니다.

* **테스트**
  * 메뉴 상세 조회 성공 및 실패(존재하지 않는 메뉴, 권한 없음) 시나리오에 대한 컨트롤러 및 서비스 테스트가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->