### PR TITLE
[Feature] 메뉴 삭제 API 구현

### DIFF
--- a/src/main/java/com/idukbaduk/itseats/menu/controller/MenuController.java
+++ b/src/main/java/com/idukbaduk/itseats/menu/controller/MenuController.java
@@ -63,7 +63,7 @@ public class MenuController {
 
     @DeleteMapping(value = "/{storeId}/menus/{menuId}")
     public ResponseEntity<BaseResponse> deleteMenu(@PathVariable Long storeId, @PathVariable Long menuId) {
-        menuService.deleteMenu(menuId);
+        menuService.deleteMenu(storeId, menuId);
         return BaseResponse.toResponseEntity(MenuResponse.DELETE_MENU_SUCCESS);
     }
 

--- a/src/main/java/com/idukbaduk/itseats/menu/controller/MenuController.java
+++ b/src/main/java/com/idukbaduk/itseats/menu/controller/MenuController.java
@@ -61,6 +61,12 @@ public class MenuController {
         );
     }
 
+    @DeleteMapping(value = "/{storeId}/menus/{menuId}")
+    public ResponseEntity<BaseResponse> deleteMenu(@PathVariable Long storeId, @PathVariable Long menuId) {
+        menuService.deleteMenu(menuId);
+        return BaseResponse.toResponseEntity(MenuResponse.DELETE_MENU_SUCCESS);
+    }
+
     @PostMapping("/{storeId}/menu-groups")
     public ResponseEntity<BaseResponse> saveMenuGroup(
             @PathVariable Long storeId,

--- a/src/main/java/com/idukbaduk/itseats/menu/dto/enums/MenuResponse.java
+++ b/src/main/java/com/idukbaduk/itseats/menu/dto/enums/MenuResponse.java
@@ -12,7 +12,7 @@ public enum MenuResponse implements Response {
     SAVE_MENU_GROUP_SUCCESS(HttpStatus.OK, "메뉴 그룹 설정 성공"),
     CREATE_MENU_SUCCESS(HttpStatus.CREATED, "메뉴 추가 성공"),
     UPDATE_MENU_SUCCESS(HttpStatus.OK, "메뉴 수정 성공"),
-    DELETE_MENU_SUCCESS(HttpStatus.CREATED, "메뉴 삭제 성공")
+    DELETE_MENU_SUCCESS(HttpStatus.OK, "메뉴 삭제 성공"),
     GET_MENU_DETAIL_SUCCESS(HttpStatus.OK, "메뉴 상세 조회 성공")
     ;
 

--- a/src/main/java/com/idukbaduk/itseats/menu/dto/enums/MenuResponse.java
+++ b/src/main/java/com/idukbaduk/itseats/menu/dto/enums/MenuResponse.java
@@ -11,7 +11,8 @@ public enum MenuResponse implements Response {
     GET_MENU_GROUP_SUCCESS(HttpStatus.OK, "메뉴 그룹 조회 성공"),
     SAVE_MENU_GROUP_SUCCESS(HttpStatus.OK, "메뉴 그룹 설정 성공"),
     CREATE_MENU_SUCCESS(HttpStatus.CREATED, "메뉴 추가 성공"),
-    UPDATE_MENU_SUCCESS(HttpStatus.OK, "메뉴 수정 성공")
+    UPDATE_MENU_SUCCESS(HttpStatus.OK, "메뉴 수정 성공"),
+    DELETE_MENU_SUCCESS(HttpStatus.CREATED, "메뉴 삭제 성공")
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/idukbaduk/itseats/menu/entity/Menu.java
+++ b/src/main/java/com/idukbaduk/itseats/menu/entity/Menu.java
@@ -7,6 +7,8 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -17,6 +19,8 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 @Table(name = "menu")
+@SQLDelete(sql = "UPDATE menu SET is_deleted = true WHERE menu_id = ?")
+@Where(clause = "is_deleted = false")
 public class Menu extends BaseEntity {
 
     @Id

--- a/src/main/java/com/idukbaduk/itseats/menu/service/MenuService.java
+++ b/src/main/java/com/idukbaduk/itseats/menu/service/MenuService.java
@@ -10,6 +10,7 @@ import com.idukbaduk.itseats.menu.repository.MenuRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.ArrayList;
@@ -20,6 +21,7 @@ import java.util.Set;
 @Slf4j
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class MenuService {
 
     private final MenuRepository menuRepository;
@@ -73,6 +75,7 @@ public class MenuService {
                 .orElseThrow(() -> new MenuException(MenuErrorCode.MENU_NOT_FOUND));
     }
 
+    @Transactional
     public MenuResponse createMenu(Long storeId, MenuRequest request, List<MultipartFile> imageFiles) {
         MenuGroup menuGroup = findMenuGroup(storeId, request.getMenuGroupName());
         validateDuplicateOptionGroupNames(request.getOptionGroups());
@@ -87,6 +90,7 @@ public class MenuService {
         return toResponse(savedMenu, images);
     }
 
+    @Transactional
     public MenuResponse updateMenu(Long storeId, Long menuId, MenuRequest request, List<MultipartFile> imageFiles) {
         Menu menu = menuRepository.findById(menuId).orElseThrow(() -> new MenuException(MenuErrorCode.MENU_NOT_FOUND));
         MenuGroup menuGroup = findMenuGroup(storeId, request.getMenuGroupName());
@@ -100,6 +104,12 @@ public class MenuService {
         List<MenuImage> images = menuMediaService.updateMenuImages(savedMenu, imageFiles);
 
         return toResponse(savedMenu, images);
+    }
+
+    @Transactional
+    public void deleteMenu(Long menuId) {
+        Menu menu = menuRepository.findById(menuId).orElseThrow(() -> new MenuException(MenuErrorCode.MENU_NOT_FOUND));
+        menuRepository.delete(menu); // is_deleted = true 설정 (@SQLDelete 이용)
     }
 
     private MenuGroup findMenuGroup(Long storeId, String menuGroupName) {

--- a/src/main/java/com/idukbaduk/itseats/menu/service/MenuService.java
+++ b/src/main/java/com/idukbaduk/itseats/menu/service/MenuService.java
@@ -109,8 +109,10 @@ public class MenuService {
     }
 
     @Transactional
-    public void deleteMenu(Long menuId) {
-        Menu menu = menuRepository.findById(menuId).orElseThrow(() -> new MenuException(MenuErrorCode.MENU_NOT_FOUND));
+    public void deleteMenu(Long storeId, Long menuId) {
+        Menu menu = menuRepository.findByStoreIdAndMenuId(storeId, menuId).orElseThrow(
+                () -> new MenuException(MenuErrorCode.MENU_NOT_FOUND)
+        );
         menuRepository.delete(menu); // is_deleted = true 설정 (@SQLDelete 이용)
     }
 

--- a/src/test/java/com/idukbaduk/itseats/menu/service/MenuServiceTest.java
+++ b/src/test/java/com/idukbaduk/itseats/menu/service/MenuServiceTest.java
@@ -413,12 +413,12 @@ class MenuServiceTest {
     @DisplayName("기존의 메뉴를 삭제 한다")
     void deleteMenu_success() {
         // given
-        when(menuRepository.findById(any())).thenReturn(Optional.of(
+        when(menuRepository.findByStoreIdAndMenuId(any(), any())).thenReturn(Optional.of(
                 Menu.builder().menuId(1L).build())
         );
 
         // when
-        menuService.deleteMenu(1L);
+        menuService.deleteMenu(1L, 1L);
 
         // then
         verify(menuRepository).delete(any(Menu.class));
@@ -428,10 +428,10 @@ class MenuServiceTest {
     @DisplayName("메뉴 삭제시 메뉴가 존재하지 않으면 예외 발생")
     void deleteMenu_notFound() {
         // given
-        when(menuRepository.findById(any())).thenReturn(Optional.empty());
+        when(menuRepository.findByStoreIdAndMenuId(any(), any())).thenReturn(Optional.empty());
 
         // when & then
-        assertThatThrownBy(() ->menuService.deleteMenu(1L))
+        assertThatThrownBy(() ->menuService.deleteMenu(1L, 1L))
                 .isInstanceOf(MenuException.class)
                 .hasMessageContaining(MenuErrorCode.MENU_NOT_FOUND.getMessage());
     }

--- a/src/test/java/com/idukbaduk/itseats/menu/service/MenuServiceTest.java
+++ b/src/test/java/com/idukbaduk/itseats/menu/service/MenuServiceTest.java
@@ -408,4 +408,31 @@ class MenuServiceTest {
                 .isInstanceOf(MenuException.class)
                 .hasMessageContaining(MenuErrorCode.OPTION_GROUP_RANGE_INVALID.getMessage());
     }
+
+    @Test
+    @DisplayName("기존의 메뉴를 삭제 한다")
+    void deleteMenu_success() {
+        // given
+        when(menuRepository.findById(any())).thenReturn(Optional.of(
+                Menu.builder().menuId(1L).build())
+        );
+
+        // when
+        menuService.deleteMenu(1L);
+
+        // then
+        verify(menuRepository).delete(any(Menu.class));
+    }
+
+    @Test
+    @DisplayName("메뉴 삭제시 메뉴가 존재하지 않으면 예외 발생")
+    void deleteMenu_notFound() {
+        // given
+        when(menuRepository.findById(any())).thenReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() ->menuService.deleteMenu(1L))
+                .isInstanceOf(MenuException.class)
+                .hasMessageContaining(MenuErrorCode.MENU_NOT_FOUND.getMessage());
+    }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

#120
closes #120

## 📝작업 내용

메뉴를 삭제하는 API를 구현합니다.

- [x] Entity 및 DTO 확인
- [x] Repository 구현
- [x] Service 구현
- [x] Controller 구현
- [x] 컨트롤러 및 서비스 테스트 코드 작성

Menu 삭제시 실제 데이터를 삭제하지 않고 `is_deleted` 필드를 1로 만듭니다. 이를 위해 Entity 클래스에 아래 설정을 통해 repository.delete() 호출시에도 아래 쿼리를 실행하도록 하였습니다.
```
@SQLDelete(sql = "UPDATE menu SET is_deleted = true WHERE menu_id = ?")
@Where(clause = "is_deleted = false")
```

### 스크린샷 (선택)

<details>
    <summary>열기</summary>

![메뉴 삭제 성공](https://github.com/user-attachments/assets/adb96d9d-f7ca-402c-8d1c-0bff73b50242)
![메뉴 삭제 결과](https://github.com/user-attachments/assets/12ceed61-69a3-44d7-b763-0f87c304c818)

</details>

## 💬리뷰 요구사항(선택)




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 메뉴 삭제 기능이 추가되어 사용자가 메뉴를 삭제할 수 있습니다.

* **버그 수정**
  * 메뉴 삭제 시 실제 데이터가 물리적으로 삭제되지 않고, 숨김 처리(소프트 딜리트)되어 조회 시 보이지 않게 변경되었습니다.

* **테스트**
  * 메뉴 삭제 성공 및 실패 케이스에 대한 테스트가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->