### PR TITLE
[Feature] 라이더 배달 거절 API 구현

### DIFF
--- a/src/main/java/com/idukbaduk/itseats/menu/controller/MenuController.java
+++ b/src/main/java/com/idukbaduk/itseats/menu/controller/MenuController.java
@@ -1,6 +1,7 @@
 package com.idukbaduk.itseats.menu.controller;
 
 import com.idukbaduk.itseats.global.response.BaseResponse;
+import com.idukbaduk.itseats.menu.dto.MenuDetailResponse;
 import com.idukbaduk.itseats.menu.dto.MenuGroupRequest;
 import com.idukbaduk.itseats.menu.dto.MenuGroupResponse;
 import com.idukbaduk.itseats.menu.dto.MenuListRequest;

--- a/src/main/java/com/idukbaduk/itseats/menu/dto/enums/MenuResponse.java
+++ b/src/main/java/com/idukbaduk/itseats/menu/dto/enums/MenuResponse.java
@@ -11,7 +11,7 @@ public enum MenuResponse implements Response {
     GET_MENU_GROUP_SUCCESS(HttpStatus.OK, "메뉴 그룹 조회 성공"),
     SAVE_MENU_GROUP_SUCCESS(HttpStatus.OK, "메뉴 그룹 설정 성공"),
     CREATE_MENU_SUCCESS(HttpStatus.CREATED, "메뉴 추가 성공"),
-    UPDATE_MENU_SUCCESS(HttpStatus.OK, "메뉴 수정 성공")
+    UPDATE_MENU_SUCCESS(HttpStatus.OK, "메뉴 수정 성공"),
     GET_MENU_DETAIL_SUCCESS(HttpStatus.OK, "메뉴 상세 조회 성공")
     ;
 

--- a/src/main/java/com/idukbaduk/itseats/rider/controller/RiderController.java
+++ b/src/main/java/com/idukbaduk/itseats/rider/controller/RiderController.java
@@ -2,6 +2,7 @@ package com.idukbaduk.itseats.rider.controller;
 
 import com.idukbaduk.itseats.global.response.BaseResponse;
 import com.idukbaduk.itseats.rider.dto.ModifyWorkingRequest;
+import com.idukbaduk.itseats.rider.dto.RejectReasonRequest;
 import com.idukbaduk.itseats.rider.dto.enums.RiderResponse;
 import com.idukbaduk.itseats.rider.service.RiderService;
 import jakarta.validation.Valid;
@@ -9,7 +10,9 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -28,6 +31,17 @@ public class RiderController {
         return BaseResponse.toResponseEntity(
                 RiderResponse.MODIFY_IS_WORKING_SUCCESS,
                 riderService.modifyWorking(userDetails.getUsername(), modifyWorkingRequest)
+        );
+    }
+
+    @PutMapping("/{orderId}/reject")
+    public ResponseEntity<BaseResponse> rejectDelivery(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @PathVariable Long orderId,
+            @RequestBody @Valid RejectReasonRequest reasonRequest) {
+        return BaseResponse.toResponseEntity(
+                RiderResponse.REJECT_DELIVERY_SUCCESS,
+                riderService.rejectDelivery(userDetails.getUsername(), orderId, reasonRequest)
         );
     }
 }

--- a/src/main/java/com/idukbaduk/itseats/rider/dto/RejectDeliveryResponse.java
+++ b/src/main/java/com/idukbaduk/itseats/rider/dto/RejectDeliveryResponse.java
@@ -1,0 +1,11 @@
+package com.idukbaduk.itseats.rider.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class RejectDeliveryResponse {
+
+    private String rejectReason;
+}

--- a/src/main/java/com/idukbaduk/itseats/rider/dto/RejectReasonRequest.java
+++ b/src/main/java/com/idukbaduk/itseats/rider/dto/RejectReasonRequest.java
@@ -1,0 +1,17 @@
+package com.idukbaduk.itseats.rider.dto;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class RejectReasonRequest {
+
+    @NotNull(message = "거절 사유는 필수값입니다.")
+    private String rejectReason;
+}

--- a/src/main/java/com/idukbaduk/itseats/rider/dto/enums/RiderResponse.java
+++ b/src/main/java/com/idukbaduk/itseats/rider/dto/enums/RiderResponse.java
@@ -11,7 +11,8 @@ public enum RiderResponse implements Response {
     UPDATE_STATUS_ACCEPT_SUCCESS(HttpStatus.OK, "배달 수락 완료"),
     UPDATE_STATUS_ARRIVED_SUCCESS(HttpStatus.OK, "매장 도착 완료"),
     UPDATE_STATUS_PICKUP_SUCCESS(HttpStatus.OK, "픽업 완료"),
-    UPDATE_STATUS_DELIVERED_SUCCESS(HttpStatus.OK, "배달 완료");
+    UPDATE_STATUS_DELIVERED_SUCCESS(HttpStatus.OK, "배달 완료"),
+    REJECT_DELIVERY_SUCCESS(HttpStatus.OK, "배달 거절 완료");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/idukbaduk/itseats/rider/entity/RiderAssignment.java
+++ b/src/main/java/com/idukbaduk/itseats/rider/entity/RiderAssignment.java
@@ -2,7 +2,6 @@ package com.idukbaduk.itseats.rider.entity;
 
 import com.idukbaduk.itseats.global.BaseEntity;
 import com.idukbaduk.itseats.order.entity.Order;
-import com.idukbaduk.itseats.rider.dto.RejectReasonRequest;
 import com.idukbaduk.itseats.rider.entity.enums.AssignmentStatus;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;

--- a/src/main/java/com/idukbaduk/itseats/rider/entity/RiderAssignment.java
+++ b/src/main/java/com/idukbaduk/itseats/rider/entity/RiderAssignment.java
@@ -1,0 +1,56 @@
+package com.idukbaduk.itseats.rider.entity;
+
+import com.idukbaduk.itseats.global.BaseEntity;
+import com.idukbaduk.itseats.order.entity.Order;
+import com.idukbaduk.itseats.rider.dto.RejectReasonRequest;
+import com.idukbaduk.itseats.rider.entity.enums.AssignmentStatus;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(name = "rider_assignment")
+public class RiderAssignment extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "assignment_id")
+    private Long assignmentId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "order_id", nullable = false)
+    private Order order;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "rider_id", nullable = false)
+    private Rider rider;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "assignment_status", nullable = false)
+    private AssignmentStatus assignmentStatus;
+
+    @Column(name = "reason")
+    private String reason;
+
+    public void rejectDelivery(AssignmentStatus assignmentStatus, String rejectReason) {
+        assignmentStatus.validateTransitionFrom(this.assignmentStatus);
+        this.assignmentStatus = assignmentStatus;
+        this.reason = rejectReason;
+    }
+}

--- a/src/main/java/com/idukbaduk/itseats/rider/entity/enums/AssignmentStatus.java
+++ b/src/main/java/com/idukbaduk/itseats/rider/entity/enums/AssignmentStatus.java
@@ -1,0 +1,26 @@
+package com.idukbaduk.itseats.rider.entity.enums;
+
+import com.idukbaduk.itseats.rider.error.RiderException;
+import com.idukbaduk.itseats.rider.error.enums.RiderErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.util.Objects;
+
+@Getter
+@RequiredArgsConstructor
+public enum AssignmentStatus {
+
+    PENDING(null),
+    ACCEPTED(PENDING),
+    REJECTED(PENDING),
+    CANCELED(ACCEPTED);
+
+    private final AssignmentStatus previousStatus;
+
+    public void validateTransitionFrom(AssignmentStatus currentStatus) {
+        if (!Objects.equals(this.previousStatus, currentStatus)) {
+            throw new RiderException(RiderErrorCode.RIDER_ASSIGNMENT_STATUS_UPDATE_FAIL);
+        }
+    }
+}

--- a/src/main/java/com/idukbaduk/itseats/rider/error/enums/RiderErrorCode.java
+++ b/src/main/java/com/idukbaduk/itseats/rider/error/enums/RiderErrorCode.java
@@ -7,7 +7,9 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum RiderErrorCode implements ErrorCode {
 
-    RIDER_NOT_FOUND(HttpStatus.NOT_FOUND, "라이더 조회 실패");
+    RIDER_NOT_FOUND(HttpStatus.NOT_FOUND, "라이더 조회 실패"),
+    RIDER_ASSIGNMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "라이더 주문 할당 정보 조회 실패"),
+    RIDER_ASSIGNMENT_STATUS_UPDATE_FAIL(HttpStatus.CONFLICT, "라이더 배차 관리 상태 변경 실패");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/idukbaduk/itseats/rider/repository/RiderAssignmentRepository.java
+++ b/src/main/java/com/idukbaduk/itseats/rider/repository/RiderAssignmentRepository.java
@@ -1,0 +1,25 @@
+package com.idukbaduk.itseats.rider.repository;
+
+import com.idukbaduk.itseats.rider.entity.RiderAssignment;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface RiderAssignmentRepository extends JpaRepository<RiderAssignment, Long> {
+
+    @Query("""
+        SELECT ra
+        FROM RiderAssignment ra
+        WHERE ra.rider.member.username = :username
+          AND ra.order.orderId = :orderId
+    """)
+    Optional<RiderAssignment> findByUsernameAndOrderId(
+            @Param("username") String username,
+            @Param("orderId") Long orderId
+    );
+
+}

--- a/src/test/java/com/idukbaduk/itseats/rider/controller/RiderControllerTest.java
+++ b/src/test/java/com/idukbaduk/itseats/rider/controller/RiderControllerTest.java
@@ -2,6 +2,8 @@ package com.idukbaduk.itseats.rider.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.idukbaduk.itseats.rider.dto.ModifyWorkingRequest;
+import com.idukbaduk.itseats.rider.dto.RejectDeliveryResponse;
+import com.idukbaduk.itseats.rider.dto.RejectReasonRequest;
 import com.idukbaduk.itseats.rider.dto.WorkingInfoResponse;
 import com.idukbaduk.itseats.rider.dto.enums.RiderResponse;
 import com.idukbaduk.itseats.rider.service.RiderService;
@@ -18,6 +20,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -73,5 +76,51 @@ class RiderControllerTest {
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.message").value("출/퇴근 여부는 필수값입니다."));
+    }
+
+    @Test
+    @DisplayName("배달 거절 성공")
+    @WithMockUser(username = "testuser")
+    void rejectDelivery_success() throws Exception {
+        // given
+        long orderId = 1L;
+
+        RejectReasonRequest request = RejectReasonRequest.builder()
+                .rejectReason("사고 발생")
+                .build();
+
+        RejectDeliveryResponse response = RejectDeliveryResponse.builder()
+                .rejectReason("사고 발생")
+                .build();
+
+        when(riderService.rejectDelivery(any(), any(), any())).thenReturn(response);
+
+        // when & then
+        mockMvc.perform(put("/api/rider/" + orderId + "/reject")
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.httpStatus")
+                        .value(RiderResponse.REJECT_DELIVERY_SUCCESS.getHttpStatus().value()))
+                .andExpect(jsonPath("$.message")
+                        .value(RiderResponse.REJECT_DELIVERY_SUCCESS.getMessage()));
+    }
+
+    @Test
+    @DisplayName("배달 거절 사유 누락시 예외 발생")
+    @WithMockUser(username = "testuser")
+    void rejectDelivery_nullReason() throws Exception {
+        // given
+        long orderId = 1L;
+        RejectReasonRequest request = RejectReasonRequest.builder().build();
+
+        // when & then
+        mockMvc.perform(put("/api/rider/" + orderId + "/reject")
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value("거절 사유는 필수값입니다."));
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

#111 

## 📝작업 내용

- 라이더가 배달 거절 사유와 함께 배달을 거절하면, 배차 상태를 거절로 바꾼 후 사유를 응답으로 반환한다.
---
- [x] DTO `RejectReasonRequest`,`RejectDeliveryResponse`, `RiderResponse` 구현 완료
- [x] Service `RiderService` 구현 완료
- [x] Controller `RiderController` 구현 완료
- [x] Test `RiderControllerTest`, `RiderServiceTest` 구현 및 작동 확인 완료
---
### `RiderAssignment` Entity 추가

- 라이더 배차 관리를 하는 테이블을 추가하였습니다.
  >  ![image](https://github.com/user-attachments/assets/2c42b0a2-0158-4aee-9329-35381cb6bf1b)
  - Order -< RiderAssignment
  - Rider -< RiderAssignment
  - 추후 Order와 Rider 주문 상태 관련 코드를 라이더 배차 관리 정보를 이용하여 리팩토링할 예정입니다!

### `AssignmentStatus`
필드명 | 상태 | 설명
--|--|--
PENDING | 배차 진행 중 | 라이더에게 배달 요청이 오면 `RiderAssignment` 테이블이 만들어진 직후 상태
ACCEPTED | 배달 수락 | 라이더가 해당 주문의 배달을 수락하면 변경되는 상태
REJECTED | 배달 거절 | 라이더가 해당 주문의 배달을 거절하면 변경되는 상태
CANCELED | 배달 취소 | 라이더가 해당 주문의 배달을 수락한 이후 배달을 취소하는 경우 변경되는 상태

- 이전 단계를 저장하고 검증하는 로직을 `OrderStatus`와 같은 방식을 사용하여 추가하였습니다.

### 스크린샷

![image](https://github.com/user-attachments/assets/9d31d27f-8261-4154-8904-f16ebf9df4ec)

![image](https://github.com/user-attachments/assets/24ece9ee-b57d-4921-8804-0b259277a505)

## 💬리뷰 요구사항

- 추가된 `RiderAssignment`의 연관관계에 이상이 있거나 추가해야할 필드가 있다면 알려주세요


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 라이더가 배달을 거절할 수 있는 기능이 추가되었습니다. 거절 사유를 입력하여 배달을 거절할 수 있습니다.

* **버그 수정**
  * 일부 enum 및 오류 코드의 구문 오류가 수정되었습니다.

* **테스트**
  * 배달 거절 기능에 대한 단위 테스트와 컨트롤러 테스트가 추가되었습니다.

* **리팩토링**
  * 라이더 및 주문 조회 방식이 개선되어 코드가 간결해졌습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->