### PR TITLE
[Feature] 배달 요청 조회 API 구현

### DIFF
--- a/src/main/java/com/idukbaduk/itseats/order/controller/RiderOrderController.java
+++ b/src/main/java/com/idukbaduk/itseats/order/controller/RiderOrderController.java
@@ -77,4 +77,13 @@ public class RiderOrderController {
         riderOrderService.updateOrderStatus(userDetails.getUsername(), orderId, OrderStatus.DELIVERED);
         return BaseResponse.toResponseEntity(RiderResponse.UPDATE_STATUS_DELIVERED_SUCCESS);
     }
+
+    @GetMapping("/request")
+    public ResponseEntity<BaseResponse> getOrderRequest(
+            @AuthenticationPrincipal UserDetails userDetails) {
+        return BaseResponse.toResponseEntity(
+                OrderResponse.GET_ORDER_REQUEST_SUCCESS,
+                riderOrderService.getOrderRequest(userDetails.getUsername())
+        );
+    }
 }

--- a/src/main/java/com/idukbaduk/itseats/order/dto/OrderRequestResponse.java
+++ b/src/main/java/com/idukbaduk/itseats/order/dto/OrderRequestResponse.java
@@ -1,0 +1,20 @@
+package com.idukbaduk.itseats.order.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class OrderRequestResponse {
+
+    private Long orderId;
+    private String deliveryType;
+    private String storeName;
+    private AddressInfoDTO myLocation;
+    private AddressInfoDTO storeLocation;
+    private int deliveryFee;
+    private String storeAddress;
+    private LocalDateTime validTime;
+}

--- a/src/main/java/com/idukbaduk/itseats/order/dto/enums/OrderResponse.java
+++ b/src/main/java/com/idukbaduk/itseats/order/dto/enums/OrderResponse.java
@@ -14,8 +14,8 @@ public enum OrderResponse implements Response {
     ACCEPT_ORDER_SUCCESS(HttpStatus.OK, "주문 수락 성공"),
     GET_RIDER_ORDER_DETAILS_SUCCESS(HttpStatus.OK, "주문 정보 조회 성공"),
     COOKED_SUCCESS(HttpStatus.OK,"조리완료"),
-    UPLOAD_RIDER_IMAGE_SUCCESS(HttpStatus.CREATED,"배달 상태 촬영 업로드 성공");
-
+    UPLOAD_RIDER_IMAGE_SUCCESS(HttpStatus.CREATED,"배달 상태 촬영 업로드 성공"),
+    GET_ORDER_REQUEST_SUCCESS(HttpStatus.OK, "배달 요청 조회 성공");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/idukbaduk/itseats/order/repository/OrderRepository.java
+++ b/src/main/java/com/idukbaduk/itseats/order/repository/OrderRepository.java
@@ -2,7 +2,6 @@ package com.idukbaduk.itseats.order.repository;
 
 import com.idukbaduk.itseats.member.entity.Member;
 import com.idukbaduk.itseats.order.entity.Order;
-import com.idukbaduk.itseats.store.entity.Store;
 import com.idukbaduk.itseats.rider.entity.Rider;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -46,7 +45,7 @@ public interface OrderRepository extends JpaRepository<Order, Long> {
     @Query(value = """
             SELECT AVG(TIMESTAMPDIFF(MINUTE, cook_start_time, order_end_time))
             FROM orders
-            WHERE store_id = :storeId 
+            WHERE store_id = :storeId
             AND cook_start_time IS NOT NULL
             AND order_end_time IS NOT NULL
             """, nativeQuery = true)
@@ -55,18 +54,18 @@ public interface OrderRepository extends JpaRepository<Order, Long> {
     @Query(value = """ 
             SELECT COUNT(*)
             FROM orders
-            WHERE store_id = :storeId 
-            AND order_end_time IS NOT NULL 
-            AND delivery_eta IS NOT NULL 
+            WHERE store_id = :storeId
+            AND order_end_time IS NOT NULL
+            AND delivery_eta IS NOT NULL
             AND ABS(TIMESTAMPDIFF(MINUTE, delivery_eta, order_end_time)) <= 5
             """, nativeQuery = true)
     Long countAccurateOrdersByStoreId(@Param("storeId") Long storeId);
 
     @Query(value = """
             SELECT AVG(TIMESTAMPDIFF(MINUTE, order_received_time, order_end_time))
-            FROM orders 
-            WHERE store_id = :storeId 
-            AND order_received_time IS NOT NULL 
+            FROM orders
+            WHERE store_id = :storeId
+            AND order_received_time IS NOT NULL
             AND order_end_time IS NOT NULL
             """ , nativeQuery = true)
     Double findAveragePickupTimeByStoreId(@Param("storeId") Long storeId);
@@ -75,9 +74,9 @@ public interface OrderRepository extends JpaRepository<Order, Long> {
             nativeQuery = true)
     Long countTotalOrdersByStoreId(@Param("storeId") Long storeId);
 
-    @Query(value = """ 
-            SELECT COUNT(*) 
-            FROM orders WHERE store_id = :storeId AND order_status 
+    @Query(value = """
+            SELECT COUNT(*)
+            FROM orders WHERE store_id = :storeId AND order_status
             IN ('COOKING', 'RIDER_READY', 'DELIVERING', 'DELIVERED', 'COMPLETED')
             """, nativeQuery = true)
     Long countAcceptedOrdersByStoreId(@Param("storeId") Long storeId);
@@ -98,4 +97,20 @@ public interface OrderRepository extends JpaRepository<Order, Long> {
     List<Order> findAllWithMenusByStoreId(@Param("storeId") Long storeId);
 
     Optional<Order> findByRiderAndOrderId(Rider rider, Long orderId);
+
+    @Query(value = """
+        SELECT o
+        FROM orders o
+        JOIN store s ON o.store_id = s.id
+        WHERE o.status = "COOKED"
+        ORDER BY ST_Distance_Sphere(
+            s.location,
+            ST_GeomFromText(CONCAT('POINT(', :riderLng, ' ', :riderLat, ')'))
+        ), o.id
+        LIMIT 1
+    """, nativeQuery = true)
+    Optional<Order> findCookedOrderByRiderLocation(
+            @Param("riderLat") double riderLat,
+            @Param("riderLng") double riderLng
+    );
 }

--- a/src/main/java/com/idukbaduk/itseats/order/repository/OrderRepository.java
+++ b/src/main/java/com/idukbaduk/itseats/order/repository/OrderRepository.java
@@ -99,14 +99,14 @@ public interface OrderRepository extends JpaRepository<Order, Long> {
     Optional<Order> findByRiderAndOrderId(Rider rider, Long orderId);
 
     @Query(value = """
-        SELECT o
+        SELECT o.*
         FROM orders o
-        JOIN store s ON o.store_id = s.id
-        WHERE o.status = "COOKED"
+        JOIN store s ON o.store_id = s.store_id
+        WHERE o.order_status = "COOKED"
         ORDER BY ST_Distance_Sphere(
             s.location,
             ST_GeomFromText(CONCAT('POINT(', :riderLng, ' ', :riderLat, ')'))
-        ), o.id
+        ), o.order_id
         LIMIT 1
     """, nativeQuery = true)
     Optional<Order> findCookedOrderByRiderLocation(

--- a/src/main/java/com/idukbaduk/itseats/order/service/RiderOrderService.java
+++ b/src/main/java/com/idukbaduk/itseats/order/service/RiderOrderService.java
@@ -138,6 +138,10 @@ public class RiderOrderService {
     public OrderRequestResponse getOrderRequest(String username) {
         Rider rider = riderRepository.findByUsername(username)
                 .orElseThrow(() -> new RiderException(RiderErrorCode.RIDER_NOT_FOUND));
+        if (rider.getLocation() == null) {
+            throw new RiderException(RiderErrorCode.RIDER_LOCATION_NOT_FOUND);
+        }
+
         Order order = orderRepository
                 .findCookedOrderByRiderLocation(rider.getLocation().getY(), rider.getLocation().getX())
                 .orElseThrow(() -> new OrderException(OrderErrorCode.ORDER_NOT_FOUND));

--- a/src/main/java/com/idukbaduk/itseats/order/service/RiderOrderService.java
+++ b/src/main/java/com/idukbaduk/itseats/order/service/RiderOrderService.java
@@ -4,8 +4,10 @@ import com.idukbaduk.itseats.member.entity.Member;
 import com.idukbaduk.itseats.member.error.MemberException;
 import com.idukbaduk.itseats.member.error.enums.MemberErrorCode;
 import com.idukbaduk.itseats.member.repository.MemberRepository;
+import com.idukbaduk.itseats.order.dto.AddressInfoDTO;
 import com.idukbaduk.itseats.order.dto.OrderDetailsResponse;
 import com.idukbaduk.itseats.order.dto.OrderItemDTO;
+import com.idukbaduk.itseats.order.dto.OrderRequestResponse;
 import com.idukbaduk.itseats.order.dto.RiderImageResponse;
 import com.idukbaduk.itseats.order.entity.Order;
 import com.idukbaduk.itseats.order.entity.enums.OrderStatus;
@@ -20,11 +22,15 @@ import com.idukbaduk.itseats.rider.entity.Rider;
 import com.idukbaduk.itseats.rider.error.RiderException;
 import com.idukbaduk.itseats.rider.error.enums.RiderErrorCode;
 import com.idukbaduk.itseats.rider.repository.RiderRepository;
+import com.idukbaduk.itseats.rider.service.RiderService;
+import com.idukbaduk.itseats.store.entity.Store;
 import lombok.RequiredArgsConstructor;
+import org.locationtech.jts.geom.Point;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Service
@@ -35,7 +41,9 @@ public class RiderOrderService {
     private final PaymentRepository paymentRepository;
     private final RiderRepository riderRepository;
     private final MemberRepository memberRepository;
+
     private final RiderImageService riderImageService;
+    private final RiderService riderService;
 
     @Transactional(readOnly = true)
     public OrderDetailsResponse getOrderDetails(String username, Long orderId) {
@@ -123,6 +131,40 @@ public class RiderOrderService {
     private RiderImageResponse buildRiderImageResponse(String imageUrl) {
         return RiderImageResponse.builder()
                 .image(imageUrl)
+                .build();
+    }
+
+    @Transactional
+    public OrderRequestResponse getOrderRequest(String username) {
+        Rider rider = riderRepository.findByUsername(username)
+                .orElseThrow(() -> new RiderException(RiderErrorCode.RIDER_NOT_FOUND));
+        Order order = orderRepository
+                .findCookedOrderByRiderLocation(rider.getLocation().getY(), rider.getLocation().getX())
+                .orElseThrow(() -> new OrderException(OrderErrorCode.ORDER_NOT_FOUND));
+        Store store = order.getStore();
+
+        riderService.createRiderAssignment(rider, order);
+
+        return buildOrderRequestResponse(rider, order, store);
+    }
+
+    private OrderRequestResponse buildOrderRequestResponse(Rider rider, Order order, Store store) {
+        return OrderRequestResponse.builder()
+                .orderId(order.getOrderId())
+                .deliveryType(order.getDeliveryType().name())
+                .storeName(store.getStoreName())
+                .myLocation(buildAddressInfoDTO(rider.getLocation()))
+                .storeLocation(buildAddressInfoDTO(store.getLocation()))
+                .deliveryFee(order.getDeliveryFee())
+                .storeAddress(store.getStoreAddress())
+                .validTime(LocalDateTime.now().plusMinutes(1))
+                .build();
+    }
+
+    private AddressInfoDTO buildAddressInfoDTO(Point location) {
+        return AddressInfoDTO.builder()
+                .lat(location.getY())
+                .lng(location.getX())
                 .build();
     }
 }

--- a/src/main/java/com/idukbaduk/itseats/rider/error/enums/RiderErrorCode.java
+++ b/src/main/java/com/idukbaduk/itseats/rider/error/enums/RiderErrorCode.java
@@ -9,7 +9,8 @@ public enum RiderErrorCode implements ErrorCode {
 
     RIDER_NOT_FOUND(HttpStatus.NOT_FOUND, "라이더 조회 실패"),
     RIDER_ASSIGNMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "라이더 주문 할당 정보 조회 실패"),
-    RIDER_ASSIGNMENT_STATUS_UPDATE_FAIL(HttpStatus.CONFLICT, "라이더 배차 관리 상태 변경 실패");
+    RIDER_ASSIGNMENT_STATUS_UPDATE_FAIL(HttpStatus.CONFLICT, "라이더 배차 관리 상태 변경 실패"),
+    RIDER_LOCATION_NOT_FOUND(HttpStatus.NOT_FOUND, "라이더 위치 정보가 없습니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/idukbaduk/itseats/rider/service/RiderService.java
+++ b/src/main/java/com/idukbaduk/itseats/rider/service/RiderService.java
@@ -1,5 +1,6 @@
 package com.idukbaduk.itseats.rider.service;
 
+import com.idukbaduk.itseats.order.entity.Order;
 import com.idukbaduk.itseats.rider.dto.ModifyWorkingRequest;
 import com.idukbaduk.itseats.rider.dto.RejectDeliveryResponse;
 import com.idukbaduk.itseats.rider.dto.RejectReasonRequest;
@@ -47,6 +48,18 @@ public class RiderService {
     private RejectDeliveryResponse buildRejectDeliveryResponse(String reason) {
         return RejectDeliveryResponse.builder()
                 .rejectReason(reason)
+                .build();
+    }
+
+    public void createRiderAssignment(Rider rider, Order order) {
+        riderAssignmentRepository.save(buildRiderAssignment(rider, order));
+    }
+
+    private RiderAssignment buildRiderAssignment(Rider rider, Order order) {
+        return RiderAssignment.builder()
+                .rider(rider)
+                .order(order)
+                .assignmentStatus(AssignmentStatus.PENDING)
                 .build();
     }
 }

--- a/src/test/java/com/idukbaduk/itseats/order/service/RiderOrderServiceTest.java
+++ b/src/test/java/com/idukbaduk/itseats/order/service/RiderOrderServiceTest.java
@@ -454,4 +454,21 @@ class RiderOrderServiceTest {
                 .isInstanceOf(OrderException.class)
                 .hasMessageContaining(OrderErrorCode.ORDER_NOT_FOUND.getMessage());
     }
+
+    @Test
+    @DisplayName("라이더 위치 정보가 없으면 예외 발생")
+    void getOrderRequest_notExistRiderLocation() {
+        // given
+        Rider noLocationRider = Rider.builder()
+                .riderId(1L)
+                .member(member)
+                .build();
+
+        when(riderRepository.findByUsername(username)).thenReturn(Optional.of(noLocationRider));
+
+        // when & then
+        assertThatThrownBy(() -> riderOrderService.getOrderRequest(username))
+                .isInstanceOf(RiderException.class)
+                .hasMessageContaining(RiderErrorCode.RIDER_LOCATION_NOT_FOUND.getMessage());
+    }
 }

--- a/src/test/java/com/idukbaduk/itseats/order/service/RiderOrderServiceTest.java
+++ b/src/test/java/com/idukbaduk/itseats/order/service/RiderOrderServiceTest.java
@@ -446,7 +446,7 @@ class RiderOrderServiceTest {
     void getOrderRequest_notExistOrder() {
         // given
         when(riderRepository.findByUsername(username)).thenReturn(Optional.of(rider));
-        when(orderRepository.findCookedOrderByRiderLocation(37.7600, 127.0000))
+        when(orderRepository.findCookedOrderByRiderLocation(rider.getLocation().getY(), rider.getLocation().getX()))
                 .thenReturn(Optional.empty());
 
         // when & then

--- a/src/test/java/com/idukbaduk/itseats/rider/service/RiderServiceTest.java
+++ b/src/test/java/com/idukbaduk/itseats/rider/service/RiderServiceTest.java
@@ -1,9 +1,7 @@
 package com.idukbaduk.itseats.rider.service;
 
 import com.idukbaduk.itseats.member.entity.Member;
-import com.idukbaduk.itseats.member.repository.MemberRepository;
 import com.idukbaduk.itseats.order.entity.Order;
-import com.idukbaduk.itseats.order.repository.OrderRepository;
 import com.idukbaduk.itseats.rider.dto.ModifyWorkingRequest;
 import com.idukbaduk.itseats.rider.dto.RejectDeliveryResponse;
 import com.idukbaduk.itseats.rider.dto.RejectReasonRequest;
@@ -19,6 +17,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -27,6 +26,8 @@ import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -168,5 +169,29 @@ class RiderServiceTest {
         assertThatThrownBy(() -> riderService.rejectDelivery(username, 1L, RejectReasonRequest.builder().build()))
                 .isInstanceOf(RiderException.class)
                 .hasMessageContaining(RiderErrorCode.RIDER_ASSIGNMENT_NOT_FOUND.getMessage());
+    }
+
+    @Test
+    @DisplayName("라이더 배차 관리 정보가 성공적으로 저장")
+    void createRiderAssignment_success() {
+        // given
+        Order order = Order.builder()
+                .orderId(1L)
+                .build();
+
+        when(riderAssignmentRepository.save(any(RiderAssignment.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        // when
+        riderService.createRiderAssignment(rider, order);
+
+        // then
+        ArgumentCaptor<RiderAssignment> captor = ArgumentCaptor.forClass(RiderAssignment.class);
+        verify(riderAssignmentRepository).save(captor.capture());
+
+        RiderAssignment savedRiderAssignment = captor.getValue();
+        assertThat(savedRiderAssignment.getRider()).isEqualTo(rider);
+        assertThat(savedRiderAssignment.getOrder()).isEqualTo(order);
+        assertThat(savedRiderAssignment.getAssignmentStatus()).isEqualTo(AssignmentStatus.PENDING);
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

#108

## 📝작업 내용

- 해당 api 요청을 보낼 시 라이더의 현재 위치와 가장 가까운(직선 거리 기준) 가게 중 배차 중(COOKED)인 주문을 조회하여 배차 상태가 PENDING인 라이더 배차 관리 테이블을 만든 후, 필요한 정보를 응답으로 반환합니다.
---
- [x] DTO `OrderResponse`, `OrderRequestResponse` 구현 완료
- [x] Service `RiderOrderService`, `RiderService` 구현 완료
- [x] Repository `OrderRepository` 구현 완료
- [x] Controller  `RiderOrderController` 구현 완료
- [x] Test `RiderOrderControllerTest`, `RiderOrderServiceTest`, `RiderServiceTest` 구현 및 작동 확인 완료
---
> 현재 `repository` 관련 테스트는 진행해보지 못한 상태입니다! 추후 확인 후 오류가 생긴다면 수정하도록 하겠습니다.

### 스크린샷

![image](https://github.com/user-attachments/assets/3f3d1e1e-4909-4194-a567-d7c8dca6be06)
![image](https://github.com/user-attachments/assets/769eb26d-2dcc-4546-853c-7f0fe80294dd)
![image](https://github.com/user-attachments/assets/4ae1c380-9083-42de-90e0-61234882c6fa)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 라이더가 자신의 위치를 기반으로 가장 가까운 조리 완료 주문을 조회할 수 있는 API가 추가되었습니다.
  * 배달 요청 조회 시 주문 ID, 배달 유형, 가게명, 라이더 및 가게 위치, 배달료, 가게 주소, 유효 시간 등의 상세 정보를 제공합니다.
  * 라이더와 주문 간 배정 기능이 도입되어 배달 요청 시 자동으로 라이더 할당이 이루어집니다.

* **버그 수정**
  * 불필요한 import 제거 및 SQL 쿼리 스타일 정리가 포함되었습니다.

* **테스트**
  * 라이더 배달 요청 조회 기능과 라이더 배정 기능에 대한 단위 테스트 및 컨트롤러 테스트가 추가되어 안정성을 강화했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->