### PR TITLE
[Fix] 가게 추가 관련 버그 수정

### DIFF
--- a/src/main/java/com/idukbaduk/itseats/store/dto/StoreCreateRequest.java
+++ b/src/main/java/com/idukbaduk/itseats/store/dto/StoreCreateRequest.java
@@ -1,14 +1,12 @@
 package com.idukbaduk.itseats.store.dto;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 
 @Getter
+@Setter
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor

--- a/src/main/java/com/idukbaduk/itseats/store/service/OwnerStoreService.java
+++ b/src/main/java/com/idukbaduk/itseats/store/service/OwnerStoreService.java
@@ -16,6 +16,8 @@ import com.idukbaduk.itseats.store.dto.StoreCreateResponse;
 import com.idukbaduk.itseats.store.entity.Franchise;
 import com.idukbaduk.itseats.store.entity.Store;
 import com.idukbaduk.itseats.store.entity.StoreCategory;
+import com.idukbaduk.itseats.store.entity.enums.BusinessStatus;
+import com.idukbaduk.itseats.store.entity.enums.StoreStatus;
 import com.idukbaduk.itseats.store.error.StoreException;
 import com.idukbaduk.itseats.store.error.enums.StoreErrorCode;
 import com.idukbaduk.itseats.store.repository.FranchiseRepository;
@@ -103,6 +105,9 @@ public class OwnerStoreService {
                 .storePhone(request.getPhone())
                 .defaultDeliveryFee(request.getDefaultDeliveryFee())
                 .onlyOneDeliveryFee(request.getOnlyOneDeliveryFee())
+                .businessStatus(BusinessStatus.OPEN)
+                .storeStatus(StoreStatus.PENDING)
+                .orderable(false)
                 .build();
 
         Store savedStore = storeRepository.save(store);


### PR DESCRIPTION
## #️⃣연관된 이슈

#132 

## 📝작업 내용

- [x] `OwnerOrderService`의 `createStore` 메서드에 `businessStatus`, `StoreStatus`, `orderable` 기본값으로 추가
- [x] `StoreCreateRequest` dto에 `@Setter` 어노테이션 추가
### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 매장 생성 시 사업 상태, 매장 상태, 주문 가능 여부가 기본값으로 초기화됩니다.

* **기타**
  * StoreCreateRequest 클래스에 setter 메서드가 추가되어 필드 수정이 가능해졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->