### PR TITLE
[Feature] 매장 상태 변경 API 구현

### DIFF
--- a/src/main/java/com/idukbaduk/itseats/store/controller/OwnerStoreController.java
+++ b/src/main/java/com/idukbaduk/itseats/store/controller/OwnerStoreController.java
@@ -37,11 +37,11 @@ public class OwnerStoreController {
     }
 
     @PostMapping("/stores/{storeId}/status")
-    public ResponseEntity<BaseResponse> updateStatus(
+    public ResponseEntity<Void> updateStatus(
             @PathVariable("storeId") Long storeId,
             @RequestBody StoreStatusUpdateRequest request
     ) {
-        StoreStatusUpdateResponse response = ownerStoreService.updateStatus(storeId, request);
-        return BaseResponse.toResponseEntity(StoreResponse.UPDATE_STATUS_SUCCESS, response);
+        ownerStoreService.updateStatus(storeId, request);
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/idukbaduk/itseats/store/controller/OwnerStoreController.java
+++ b/src/main/java/com/idukbaduk/itseats/store/controller/OwnerStoreController.java
@@ -1,25 +1,18 @@
 package com.idukbaduk.itseats.store.controller;
 
 import com.idukbaduk.itseats.global.response.BaseResponse;
-import com.idukbaduk.itseats.store.dto.StoreDashboardResponse;
+import com.idukbaduk.itseats.store.dto.*;
 import com.idukbaduk.itseats.store.service.OwnerStoreService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import com.idukbaduk.itseats.store.dto.StoreCreateRequest;
-import com.idukbaduk.itseats.store.dto.StoreCreateResponse;
+import org.springframework.web.bind.annotation.*;
 import com.idukbaduk.itseats.store.dto.enums.StoreResponse;
 import com.idukbaduk.itseats.store.service.OwnerStoreService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.web.bind.annotation.ModelAttribute;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
@@ -41,5 +34,14 @@ public class OwnerStoreController {
     ) {
         StoreCreateResponse response = ownerStoreService.createStore(userDetails.getUsername(), request);
         return BaseResponse.toResponseEntity(StoreResponse.CREATE_STORE_SUCCESS, response);
+    }
+
+    @PostMapping("/stores/{storeId}/status")
+    public ResponseEntity<BaseResponse> updateStatus(
+            @PathVariable("storeId") Long storeId,
+            @RequestBody StoreStatusUpdateRequest request
+    ) {
+        StoreStatusUpdateResponse response = ownerStoreService.updateStatus(storeId, request);
+        return BaseResponse.toResponseEntity(StoreResponse.UPDATE_STATUS_SUCCESS, response);
     }
 }

--- a/src/main/java/com/idukbaduk/itseats/store/dto/StoreStatusUpdateRequest.java
+++ b/src/main/java/com/idukbaduk/itseats/store/dto/StoreStatusUpdateRequest.java
@@ -1,0 +1,18 @@
+package com.idukbaduk.itseats.store.dto;
+
+import com.idukbaduk.itseats.store.entity.enums.BusinessStatus;
+import com.idukbaduk.itseats.store.entity.enums.StoreStatus;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class StoreStatusUpdateRequest {
+    private BusinessStatus businessStatus;
+    private StoreStatus storeStatus;
+    private Boolean orderable;
+}

--- a/src/main/java/com/idukbaduk/itseats/store/dto/StoreStatusUpdateResponse.java
+++ b/src/main/java/com/idukbaduk/itseats/store/dto/StoreStatusUpdateResponse.java
@@ -1,0 +1,10 @@
+package com.idukbaduk.itseats.store.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class StoreStatusUpdateResponse {
+    private boolean updated;
+}

--- a/src/main/java/com/idukbaduk/itseats/store/dto/enums/StoreResponse.java
+++ b/src/main/java/com/idukbaduk/itseats/store/dto/enums/StoreResponse.java
@@ -8,6 +8,7 @@ import org.springframework.http.HttpStatus;
 public enum StoreResponse implements Response {
 
     CREATE_STORE_SUCCESS(HttpStatus.CREATED, "가게 추가 성공"),
+    UPDATE_STATUS_SUCCESS(HttpStatus.OK, "가게 상태 변경 성공")
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/idukbaduk/itseats/store/entity/Store.java
+++ b/src/main/java/com/idukbaduk/itseats/store/entity/Store.java
@@ -67,4 +67,16 @@ public class Store extends BaseEntity {
 
     @Column(name = "only_one_delivery_fee", nullable = false)
     private int onlyOneDeliveryFee;
+
+    public void updateBusinessStatus(BusinessStatus newBusinessStatus) {
+        this.businessStatus = newBusinessStatus;
+    }
+
+    public void updateStoreStatus(StoreStatus newStoreStatus) {
+        this.storeStatus = newStoreStatus;
+    }
+
+    public void updateOrderable(Boolean orderable) {
+        this.orderable = orderable;
+    }
 }

--- a/src/main/java/com/idukbaduk/itseats/store/service/OwnerStoreService.java
+++ b/src/main/java/com/idukbaduk/itseats/store/service/OwnerStoreService.java
@@ -119,27 +119,18 @@ public class OwnerStoreService {
     }
 
     @Transactional
-    public StoreStatusUpdateResponse updateStatus(Long storeId, StoreStatusUpdateRequest request) {
+    public void updateStatus(Long storeId, StoreStatusUpdateRequest request) {
         Store store = storeRepository.findById(storeId)
                 .orElseThrow(() -> new StoreException(StoreErrorCode.STORE_NOT_FOUND));
 
-        boolean updated = false;
-
         if (request.getBusinessStatus() != null) {
             store.updateBusinessStatus(request.getBusinessStatus());
-            updated = true;
         }
-
         if (request.getStoreStatus() != null) {
             store.updateStoreStatus(request.getStoreStatus());
-            updated = true;
         }
-
         if (request.getOrderable() != null) {
             store.updateOrderable(request.getOrderable());
-            updated = true;
         }
-
-        return new StoreStatusUpdateResponse(updated);
     }
 }

--- a/src/main/java/com/idukbaduk/itseats/store/service/OwnerStoreService.java
+++ b/src/main/java/com/idukbaduk/itseats/store/service/OwnerStoreService.java
@@ -5,14 +5,12 @@ import com.idukbaduk.itseats.order.entity.Order;
 import com.idukbaduk.itseats.order.entity.enums.OrderStatus;
 import com.idukbaduk.itseats.order.repository.OrderRepository;
 import com.idukbaduk.itseats.review.repository.ReviewRepository;
-import com.idukbaduk.itseats.store.dto.StoreDashboardResponse;
+import com.idukbaduk.itseats.store.dto.*;
 import com.idukbaduk.itseats.member.entity.Member;
 import com.idukbaduk.itseats.member.error.MemberException;
 import com.idukbaduk.itseats.member.error.enums.MemberErrorCode;
 import com.idukbaduk.itseats.member.repository.MemberRepository;
 import com.idukbaduk.itseats.member.service.MemberService;
-import com.idukbaduk.itseats.store.dto.StoreCreateRequest;
-import com.idukbaduk.itseats.store.dto.StoreCreateResponse;
 import com.idukbaduk.itseats.store.entity.Franchise;
 import com.idukbaduk.itseats.store.entity.Store;
 import com.idukbaduk.itseats.store.entity.StoreCategory;
@@ -118,5 +116,30 @@ public class OwnerStoreService {
                 .address(savedStore.getStoreAddress())
                 .phone(savedStore.getStorePhone())
                 .build();
+    }
+
+    @Transactional
+    public StoreStatusUpdateResponse updateStatus(Long storeId, StoreStatusUpdateRequest request) {
+        Store store = storeRepository.findById(storeId)
+                .orElseThrow(() -> new StoreException(StoreErrorCode.STORE_NOT_FOUND));
+
+        boolean updated = false;
+
+        if (request.getBusinessStatus() != null) {
+            store.updateBusinessStatus(request.getBusinessStatus());
+            updated = true;
+        }
+
+        if (request.getStoreStatus() != null) {
+            store.updateStoreStatus(request.getStoreStatus());
+            updated = true;
+        }
+
+        if (request.getOrderable() != null) {
+            store.updateOrderable(request.getOrderable());
+            updated = true;
+        }
+
+        return new StoreStatusUpdateResponse(updated);
     }
 }

--- a/src/test/java/com/idukbaduk/itseats/store/service/OwnerStoreServiceTest.java
+++ b/src/test/java/com/idukbaduk/itseats/store/service/OwnerStoreServiceTest.java
@@ -155,8 +155,8 @@ class OwnerStoreServiceTest {
     }
 
     @Test
-    @DisplayName("매장 상태 변경 성공 - 변경된 값 있음")
-    void updateStatus_successWithChanges() {
+    @DisplayName("가게 상태 변경 성공 - 모든 필드 변경")
+    void updateStatus_successAllFields() {
         // given
         Long storeId = 1L;
         StoreStatusUpdateRequest request = new StoreStatusUpdateRequest(
@@ -164,46 +164,49 @@ class OwnerStoreServiceTest {
                 StoreStatus.REJECTED,
                 true
         );
-
         Store store = mock(Store.class);
+
         when(storeRepository.findById(storeId)).thenReturn(Optional.of(store));
 
         // when
-        StoreStatusUpdateResponse response = ownerStoreService.updateStatus(storeId, request);
+        ownerStoreService.updateStatus(storeId, request);
 
         // then
-        assertThat(response.isUpdated()).isTrue();
         verify(store).updateBusinessStatus(BusinessStatus.CLOSE);
         verify(store).updateStoreStatus(StoreStatus.REJECTED);
         verify(store).updateOrderable(true);
     }
 
     @Test
-    @DisplayName("매장 상태 변경 성공 - 변경된 값 없음")
-    void updateStatus_successNoChanges() {
+    @DisplayName("가게 상태 변경 성공 - 일부 필드만 변경")
+    void updateStatus_successPartialFields() {
         // given
         Long storeId = 1L;
-        StoreStatusUpdateRequest request = new StoreStatusUpdateRequest(null, null, null);
-
+        StoreStatusUpdateRequest request = new StoreStatusUpdateRequest(
+                BusinessStatus.CLOSE,
+                null,
+                null
+        );
         Store store = mock(Store.class);
+
         when(storeRepository.findById(storeId)).thenReturn(Optional.of(store));
 
         // when
-        StoreStatusUpdateResponse response = ownerStoreService.updateStatus(storeId, request);
+        ownerStoreService.updateStatus(storeId, request);
 
         // then
-        assertThat(response.isUpdated()).isFalse();
-        verify(store, never()).updateBusinessStatus(any());
+        verify(store).updateBusinessStatus(BusinessStatus.CLOSE);
         verify(store, never()).updateStoreStatus(any());
         verify(store, never()).updateOrderable(any());
     }
 
     @Test
-    @DisplayName("매장 상태 변경 실패 - 존재하지 않는 매장")
+    @DisplayName("가게 상태 변경 실패 - 매장 없음")
     void updateStatus_storeNotFound() {
         // given
         Long storeId = 99L;
         StoreStatusUpdateRequest request = new StoreStatusUpdateRequest(null, null, null);
+
         when(storeRepository.findById(storeId)).thenReturn(Optional.empty());
 
         // when & then


### PR DESCRIPTION
## #️⃣연관된 이슈

#136 

## 📝작업 내용
- [ ] `StoreStatusUpdateRequset`, `StoreStatusUpdateResponse` 작성
- [ ] 서비스, 컨트롤러 추가
- [ ] 테스트 코드 작성 후 작동확인 완료

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 점주가 매장 상태(영업 상태, 매장 상태, 주문 가능 여부)를 변경할 수 있는 API가 추가되었습니다.

* **버그 수정**
  * 매장 상태 변경 시 성공 및 실패에 대한 응답 메시지가 개선되었습니다.

* **테스트**
  * 매장 상태 변경 API에 대한 성공, 실패, 부분 변경 등 다양한 케이스의 테스트가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->