### PR TITLE
[Fix] 주문 생성 관련 오류 수정

### DIFF
--- a/src/main/java/com/idukbaduk/itseats/order/entity/Order.java
+++ b/src/main/java/com/idukbaduk/itseats/order/entity/Order.java
@@ -72,10 +72,10 @@ public class Order extends BaseEntity {
     @Column(name = "store_location", columnDefinition = "POINT", nullable = false)
     private Point storeLocation;
 
-    @Column(name = "order_received_time", nullable = false)
+    @Column(name = "order_received_time")
     private LocalDateTime orderReceivedTime;
 
-    @Column(name = "cook_start_time", nullable = false)
+    @Column(name = "cook_start_time")
     private LocalDateTime cookStartTime;
 
     @Column(name = "order_end_time")


### PR DESCRIPTION
## #️⃣연관된 이슈

#152
closes #152

## 📝작업 내용

1차 프로젝트 발표 준비 중 발견한 주문 생성(결제 API) 관련 오류를 수정합니다.
- 주문 생성시 `orderReceivedTime`과 `cookStartTime` 필드에 `null` 허용
- 과거 주문 데이터가 없을 때 `findMinDeliveryTimeByType` 등 주문 소요 시간 추정시 `null` 예외 처리

## 💬리뷰 요구사항(선택)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 배달 시간 관련 정보가 없을 때 기본값(30분 등)이 제공되어 오류 발생 가능성이 줄어듦.
  * 오타가 있던 메서드명이 수정되어 일관성이 향상됨.

* **기타**
  * 일부 필수 입력값(주문 접수 시간, 조리 시작 시간)이 선택 사항으로 변경되어 입력이 없어도 주문이 가능해졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->