### PR TITLE
chore: Config 패키지 이동, 시큐리티 CORS 설정

### DIFF
--- a/src/main/java/com/idukbaduk/itseats/global/config/CorsConfig.java
+++ b/src/main/java/com/idukbaduk/itseats/global/config/CorsConfig.java
@@ -1,4 +1,4 @@
-package com.idukbaduk.itseats.global;
+package com.idukbaduk.itseats.global.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/src/main/java/com/idukbaduk/itseats/global/config/JpaConfig.java
+++ b/src/main/java/com/idukbaduk/itseats/global/config/JpaConfig.java
@@ -1,4 +1,4 @@
-package com.idukbaduk.itseats.global;
+package com.idukbaduk.itseats.global.config;
 
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;

--- a/src/main/java/com/idukbaduk/itseats/global/config/S3Config.java
+++ b/src/main/java/com/idukbaduk/itseats/global/config/S3Config.java
@@ -1,4 +1,4 @@
-package com.idukbaduk.itseats.global;
+package com.idukbaduk.itseats.global.config;
 
 import lombok.Getter;
 import org.springframework.beans.factory.annotation.Value;
@@ -12,7 +12,6 @@ import software.amazon.awssdk.services.s3.S3ClientBuilder;
 import software.amazon.awssdk.services.s3.S3Configuration;
 
 import java.net.URI;
-import java.util.Optional;
 
 @Configuration
 public class S3Config {

--- a/src/main/java/com/idukbaduk/itseats/global/config/SecurityConfig.java
+++ b/src/main/java/com/idukbaduk/itseats/global/config/SecurityConfig.java
@@ -7,6 +7,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -34,6 +35,7 @@ public class SecurityConfig {
     public SecurityFilterChain filterChain(HttpSecurity http, AuthenticationManager authenticationManager) throws Exception {
         http
                 .csrf(AbstractHttpConfigurer::disable)
+                .cors(Customizer.withDefaults())
 
                 .authorizeHttpRequests(authorize -> authorize
                         .requestMatchers(PERMIT_URL_ARRAY).permitAll()

--- a/src/main/java/com/idukbaduk/itseats/global/util/S3Utils.java
+++ b/src/main/java/com/idukbaduk/itseats/global/util/S3Utils.java
@@ -1,7 +1,7 @@
 package com.idukbaduk.itseats.global.util;
 
 
-import com.idukbaduk.itseats.global.S3Config;
+import com.idukbaduk.itseats.global.config.S3Config;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.web.multipart.MultipartFile;


### PR DESCRIPTION
## #️⃣연관된 이슈

#154
closes #154

## 📝작업 내용

global 패키지에 있는 `CorsConfig`, `JpaConfig`, `S3Config` 클래스를 global.config 패키지로 이동합니다.
또한, `SecurityConfig`에 기본 CorsConfig 설정을 사용하도록 설정합니다.


## 💬리뷰 요구사항(선택)

없음
