### PR TITLE
[Feature] 주문 재개 API 구현

### DIFF
--- a/src/main/java/com/idukbaduk/itseats/store/controller/OwnerStoreController.java
+++ b/src/main/java/com/idukbaduk/itseats/store/controller/OwnerStoreController.java
@@ -46,4 +46,10 @@ public class OwnerStoreController {
         ownerStoreService.updateStatus(storeId, request);
         return ResponseEntity.ok().build();
     }
+
+    @PostMapping("/{storeId}/start")
+    public ResponseEntity<Void> restartOrder(@PathVariable("storeId") Long storeId) {
+        ownerStoreService.restartOrder(storeId);
+        return ResponseEntity.ok().build();
+    }
 }

--- a/src/main/java/com/idukbaduk/itseats/store/service/OwnerStoreService.java
+++ b/src/main/java/com/idukbaduk/itseats/store/service/OwnerStoreService.java
@@ -139,4 +139,11 @@ public class OwnerStoreService {
             store.updateOrderable(request.getOrderable());
         }
     }
+
+    @Transactional
+    public void restartOrder(Long storeId) {
+        Store store = storeRepository.findById(storeId)
+                .orElseThrow(() -> new StoreException(StoreErrorCode.STORE_NOT_FOUND));
+        store.updateOrderable(true);
+    }
 }

--- a/src/test/java/com/idukbaduk/itseats/store/controller/OwnerStoreControllerTest.java
+++ b/src/test/java/com/idukbaduk/itseats/store/controller/OwnerStoreControllerTest.java
@@ -30,6 +30,7 @@ import java.nio.charset.StandardCharsets;
 
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willDoNothing;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
@@ -169,5 +170,18 @@ class OwnerStoreControllerTest {
                 "request", "request.json", "application/json", requestJson.getBytes(StandardCharsets.UTF_8)
         );
         return requestPart;
+    }
+
+    @Test
+    @DisplayName("주문 재개 성공 응답")
+    void restartOrder_success() throws Exception {
+        // given
+        Long storeId = 12L;
+        willDoNothing().given(ownerStoreService).restartOrder(storeId);
+
+        // when & then
+        mockMvc.perform(post("/api/owner/{storeId}/start", storeId)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk());
     }
 }

--- a/src/test/java/com/idukbaduk/itseats/store/service/OwnerStoreServiceTest.java
+++ b/src/test/java/com/idukbaduk/itseats/store/service/OwnerStoreServiceTest.java
@@ -30,6 +30,7 @@ import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
@@ -214,5 +215,23 @@ class OwnerStoreServiceTest {
         assertThatThrownBy(() -> ownerStoreService.updateStatus(storeId, request))
                 .isInstanceOf(StoreException.class)
                 .hasMessageContaining(StoreErrorCode.STORE_NOT_FOUND.getMessage());
+    }
+
+    @Test
+    @DisplayName("주문 재개 성공")
+    void restartOrder_success() {
+        // given
+        Long storeId = 12L;
+        Store store = Store.builder()
+                .storeId(storeId)
+                .orderable(false)
+                .build();
+        given(storeRepository.findById(storeId)).willReturn(Optional.of(store));
+
+        // when
+        ownerStoreService.restartOrder(storeId);
+
+        // then
+        assertThat(store.getOrderable()).isTrue();
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

#158 

## 📝작업 내용

- [ ] `OwnerStoreService`, `OwnerStoreController`에 주문 재개 관련 메서드 추가

### 스크린샷 (선택)
<img width="425" alt="image" src="https://github.com/user-attachments/assets/9bed190b-295b-4964-b6a2-86e2428ee75f" />

<img width="427" alt="image" src="https://github.com/user-attachments/assets/08c61443-5b8e-49c0-9eea-5ab540d48cb8" />

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 매장 주문 재시작을 위한 새로운 엔드포인트가 추가되었습니다. 이제 매장주는 주문을 다시 시작할 수 있습니다.

* **테스트**
  * 주문 재시작 기능에 대한 컨트롤러 및 서비스 테스트가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->