### PR TITLE
[Feature] 주문 일시정지 API 구현

### DIFF
--- a/src/main/java/com/idukbaduk/itseats/store/controller/OwnerStoreController.java
+++ b/src/main/java/com/idukbaduk/itseats/store/controller/OwnerStoreController.java
@@ -3,6 +3,7 @@ package com.idukbaduk.itseats.store.controller;
 import com.idukbaduk.itseats.global.response.BaseResponse;
 import com.idukbaduk.itseats.store.dto.*;
 import com.idukbaduk.itseats.store.service.OwnerStoreService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -45,5 +46,13 @@ public class OwnerStoreController {
     ) {
         ownerStoreService.updateStatus(storeId, request);
         return ResponseEntity.ok().build();
+    }
+
+    @PostMapping("/{storeId}/pause")
+    public ResponseEntity<BaseResponse> pauseOrder(
+            @PathVariable("storeId") Long storeId,
+            @RequestBody @Valid StorePauseRequest request) {
+        StorePauseResponse response = ownerStoreService.pauseOrder(storeId, request.getPauseTime());
+        return BaseResponse.toResponseEntity(StoreResponse.PAUSE_ORDER_SUCCESS, response);
     }
 }

--- a/src/main/java/com/idukbaduk/itseats/store/dto/StorePauseRequest.java
+++ b/src/main/java/com/idukbaduk/itseats/store/dto/StorePauseRequest.java
@@ -1,0 +1,16 @@
+package com.idukbaduk.itseats.store.dto;
+
+import jakarta.validation.constraints.Min;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class StorePauseRequest {
+    @Min(value = 1, message = "일시정지 시간은 1분 이상이어야 합니다.")
+    private int pauseTime;
+}

--- a/src/main/java/com/idukbaduk/itseats/store/dto/StorePauseResponse.java
+++ b/src/main/java/com/idukbaduk/itseats/store/dto/StorePauseResponse.java
@@ -1,0 +1,13 @@
+package com.idukbaduk.itseats.store.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class StorePauseResponse {
+    private Long storeId;
+    private boolean orderable;
+    private int pauseTime;
+    private String restartTime;
+}

--- a/src/main/java/com/idukbaduk/itseats/store/dto/enums/StoreResponse.java
+++ b/src/main/java/com/idukbaduk/itseats/store/dto/enums/StoreResponse.java
@@ -8,7 +8,8 @@ import org.springframework.http.HttpStatus;
 public enum StoreResponse implements Response {
 
     CREATE_STORE_SUCCESS(HttpStatus.CREATED, "가게 추가 성공"),
-    UPDATE_STATUS_SUCCESS(HttpStatus.OK, "가게 상태 변경 성공")
+    UPDATE_STATUS_SUCCESS(HttpStatus.OK, "가게 상태 변경 성공"),
+    PAUSE_ORDER_SUCCESS(HttpStatus.CREATED, "주문 일시정지 성공")
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/idukbaduk/itseats/store/service/OwnerStoreService.java
+++ b/src/main/java/com/idukbaduk/itseats/store/service/OwnerStoreService.java
@@ -28,6 +28,8 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.time.Duration;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 
 @Service
@@ -138,5 +140,23 @@ public class OwnerStoreService {
         if (request.getOrderable() != null) {
             store.updateOrderable(request.getOrderable());
         }
+    }
+
+    @Transactional
+    public StorePauseResponse pauseOrder(Long storeId, int pauseTime) {
+        Store store = storeRepository.findById(storeId)
+                .orElseThrow(() -> new StoreException(StoreErrorCode.STORE_NOT_FOUND));
+
+        store.updateOrderable(false);
+
+        LocalDateTime restartTime = LocalDateTime.now().plusMinutes(pauseTime);
+        String restartTimeStr = restartTime.format(DateTimeFormatter.ofPattern("MM.dd HH:mm"));
+
+        return StorePauseResponse.builder()
+                .storeId(store.getStoreId())
+                .orderable(store.getOrderable())
+                .pauseTime(pauseTime)
+                .restartTime(restartTimeStr)
+                .build();
     }
 }

--- a/src/test/java/com/idukbaduk/itseats/store/service/OwnerStoreServiceTest.java
+++ b/src/test/java/com/idukbaduk/itseats/store/service/OwnerStoreServiceTest.java
@@ -2,10 +2,7 @@ package com.idukbaduk.itseats.store.service;
 
 import com.idukbaduk.itseats.member.entity.Member;
 import com.idukbaduk.itseats.member.repository.MemberRepository;
-import com.idukbaduk.itseats.store.dto.StoreCreateRequest;
-import com.idukbaduk.itseats.store.dto.StoreCreateResponse;
-import com.idukbaduk.itseats.store.dto.StoreStatusUpdateRequest;
-import com.idukbaduk.itseats.store.dto.StoreStatusUpdateResponse;
+import com.idukbaduk.itseats.store.dto.*;
 import com.idukbaduk.itseats.store.entity.Franchise;
 import com.idukbaduk.itseats.store.entity.Store;
 import com.idukbaduk.itseats.store.entity.StoreCategory;
@@ -30,6 +27,7 @@ import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
@@ -214,5 +212,27 @@ class OwnerStoreServiceTest {
         assertThatThrownBy(() -> ownerStoreService.updateStatus(storeId, request))
                 .isInstanceOf(StoreException.class)
                 .hasMessageContaining(StoreErrorCode.STORE_NOT_FOUND.getMessage());
+    }
+
+    @Test
+    @DisplayName("주문 일시정지 성공")
+    void pauseOrder_success() {
+        // given
+        Long storeId = 12L;
+        int pauseTime = 15;
+        Store store = Store.builder()
+                .storeId(storeId)
+                .orderable(true)
+                .build();
+        given(storeRepository.findById(storeId)).willReturn(Optional.of(store));
+
+        // when
+        StorePauseResponse response = ownerStoreService.pauseOrder(storeId, pauseTime);
+
+        // then
+        assertThat(response.getStoreId()).isEqualTo(storeId);
+        assertThat(response.isOrderable()).isFalse();
+        assertThat(response.getPauseTime()).isEqualTo(pauseTime);
+        assertThat(response.getRestartTime()).isNotNull();
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈
#157 

## 📝작업 내용
- [ ] `StorePauseRequest`, `StorePauseResponse` dto 작성
- [ ] `OwnerStoreService`, `OwnerStoreController`에 주문 일시정지 관련 메서드 추가

### 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/1fbcc413-8b14-44f4-9cd7-1a6d9a5d9640)
![image](https://github.com/user-attachments/assets/3e1e64c0-6643-4f19-aaa7-d504de8b0ec6)
## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
