### PR TITLE
[Feature] 예상 조리시간 설정 API 구현

### DIFF
--- a/src/main/java/com/idukbaduk/itseats/order/controller/OwnerOrderController.java
+++ b/src/main/java/com/idukbaduk/itseats/order/controller/OwnerOrderController.java
@@ -1,12 +1,7 @@
 package com.idukbaduk.itseats.order.controller;
 
 import com.idukbaduk.itseats.global.response.BaseResponse;
-import com.idukbaduk.itseats.order.dto.OrderCookedResponse;
-import com.idukbaduk.itseats.order.dto.OrderDetailResponse;
-import com.idukbaduk.itseats.order.dto.OrderAcceptResponse;
-import com.idukbaduk.itseats.order.dto.OrderReceptionResponse;
-import com.idukbaduk.itseats.order.dto.OrderRejectRequest;
-import com.idukbaduk.itseats.order.dto.OrderRejectResponse;
+import com.idukbaduk.itseats.order.dto.*;
 import com.idukbaduk.itseats.order.dto.enums.OrderResponse;
 import com.idukbaduk.itseats.order.service.OwnerOrderService;
 import jakarta.validation.Valid;
@@ -43,7 +38,7 @@ public class OwnerOrderController {
         OrderRejectResponse response = ownerOrderService.rejectOrder(orderId, request.getReason());
         return BaseResponse.toResponseEntity(OrderResponse.REJECT_ORDER_SUCCESS, response);
     }
-  
+
     @PostMapping("/orders/{orderId}/accept")
     public ResponseEntity<BaseResponse> acceptOrder(@PathVariable("orderId") Long orderId) {
         OrderAcceptResponse response = ownerOrderService.acceptOrder(orderId);
@@ -54,5 +49,14 @@ public class OwnerOrderController {
     public ResponseEntity<BaseResponse> cookingComplete(@PathVariable("orderId") Long orderId) {
         OrderCookedResponse response = ownerOrderService.markAsCooked(orderId);
         return BaseResponse.toResponseEntity(OrderResponse.COOKED_SUCCESS, response);
+    }
+
+    @PostMapping("/orders/{orderId}/cooktime")
+    public ResponseEntity<BaseResponse> setCookTime(
+            @PathVariable("orderId") Long orderId,
+            @RequestBody @Valid CookTimeRequest request
+    ) {
+        CookTimeResponse response = ownerOrderService.setCookTime(orderId, request.getCookTime());
+        return BaseResponse.toResponseEntity(OrderResponse.SET_COOKTIME_SUCCESS, response);
     }
 }

--- a/src/main/java/com/idukbaduk/itseats/order/dto/CookTimeRequest.java
+++ b/src/main/java/com/idukbaduk/itseats/order/dto/CookTimeRequest.java
@@ -1,0 +1,16 @@
+package com.idukbaduk.itseats.order.dto;
+
+import jakarta.validation.constraints.Min;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CookTimeRequest {
+    @Min(value = 1, message = "예상 조리 시간은 1분 이상이어야 합니다.")
+    private int cookTime;
+}

--- a/src/main/java/com/idukbaduk/itseats/order/dto/CookTimeResponse.java
+++ b/src/main/java/com/idukbaduk/itseats/order/dto/CookTimeResponse.java
@@ -1,0 +1,11 @@
+package com.idukbaduk.itseats.order.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class CookTimeResponse {
+    private Long orderId;
+    private String deliveryEta;
+}

--- a/src/main/java/com/idukbaduk/itseats/order/dto/enums/OrderResponse.java
+++ b/src/main/java/com/idukbaduk/itseats/order/dto/enums/OrderResponse.java
@@ -15,7 +15,9 @@ public enum OrderResponse implements Response {
     GET_RIDER_ORDER_DETAILS_SUCCESS(HttpStatus.OK, "주문 정보 조회 성공"),
     COOKED_SUCCESS(HttpStatus.OK,"조리완료"),
     UPLOAD_RIDER_IMAGE_SUCCESS(HttpStatus.CREATED,"배달 상태 촬영 업로드 성공"),
-    GET_ORDER_REQUEST_SUCCESS(HttpStatus.OK, "배달 요청 조회 성공");
+    GET_ORDER_REQUEST_SUCCESS(HttpStatus.OK, "배달 요청 조회 성공"),
+    SET_COOKTIME_SUCCESS(HttpStatus.CREATED, "예상 조리시간 설정 성공")
+    ;
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/idukbaduk/itseats/order/entity/Order.java
+++ b/src/main/java/com/idukbaduk/itseats/order/entity/Order.java
@@ -107,4 +107,8 @@ public class Order extends BaseEntity {
         this.orderStatus = OrderStatus.REJECTED;
         this.rejectReason = reason;
     }
+
+    public void updateDeliveryEta(LocalDateTime deliveryEta) {
+        this.deliveryEta = deliveryEta;
+    }
 }

--- a/src/main/java/com/idukbaduk/itseats/order/service/OwnerOrderService.java
+++ b/src/main/java/com/idukbaduk/itseats/order/service/OwnerOrderService.java
@@ -18,6 +18,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
@@ -143,5 +145,21 @@ public class OwnerOrderService {
         order.updateStatus(OrderStatus.COOKED);
 
         return new OrderCookedResponse(true);
+    }
+
+    @Transactional
+    public CookTimeResponse setCookTime(Long orderId, int cookTime) {
+        Order order = orderRepository.findById(orderId)
+                .orElseThrow(() -> new OrderException(OrderErrorCode.ORDER_NOT_FOUND));
+
+        LocalDateTime deliveryEta = LocalDateTime.now().plusMinutes(cookTime);
+        order.updateDeliveryEta(deliveryEta);
+
+        String etaStr = deliveryEta.format(DateTimeFormatter.ofPattern("MM.dd HH:mm"));
+
+        return CookTimeResponse.builder()
+                .orderId(order.getOrderId())
+                .deliveryEta(etaStr)
+                .build();
     }
 }

--- a/src/main/java/com/idukbaduk/itseats/order/service/OwnerOrderService.java
+++ b/src/main/java/com/idukbaduk/itseats/order/service/OwnerOrderService.java
@@ -152,9 +152,8 @@ public class OwnerOrderService {
         Order order = orderRepository.findById(orderId)
                 .orElseThrow(() -> new OrderException(OrderErrorCode.ORDER_NOT_FOUND));
 
-        if (order.getOrderStatus() == OrderStatus.COMPLETED || order.getOrderStatus() == OrderStatus.REJECTED) {
-            throw new OrderException(OrderErrorCode.INVALID_ORDER_STATUS);
-        }
+        OrderStatus nextStatus = OrderStatus.COOKING;
+        nextStatus.validateTransitionFrom(order.getOrderStatus());
 
         LocalDateTime deliveryEta = LocalDateTime.now().plusMinutes(cookTime);
         order.updateDeliveryEta(deliveryEta);

--- a/src/main/java/com/idukbaduk/itseats/order/service/OwnerOrderService.java
+++ b/src/main/java/com/idukbaduk/itseats/order/service/OwnerOrderService.java
@@ -152,6 +152,10 @@ public class OwnerOrderService {
         Order order = orderRepository.findById(orderId)
                 .orElseThrow(() -> new OrderException(OrderErrorCode.ORDER_NOT_FOUND));
 
+        if (order.getOrderStatus() == OrderStatus.COMPLETED || order.getOrderStatus() == OrderStatus.REJECTED) {
+            throw new OrderException(OrderErrorCode.INVALID_ORDER_STATUS);
+        }
+
         LocalDateTime deliveryEta = LocalDateTime.now().plusMinutes(cookTime);
         order.updateDeliveryEta(deliveryEta);
 

--- a/src/test/java/com/idukbaduk/itseats/order/service/OwnerOrderServiceTest.java
+++ b/src/test/java/com/idukbaduk/itseats/order/service/OwnerOrderServiceTest.java
@@ -194,29 +194,7 @@ class OwnerOrderServiceTest {
     }
 
     @Test
-    @DisplayName("예상 조리 시간 설정 성공")
-    void setCookTime_success() {
-        // given
-        Long orderId = 12L;
-        int cookTime = 15;
-        Order order = Order.builder()
-                .orderId(orderId)
-                .build();
-        given(orderRepository.findById(orderId)).willReturn(Optional.of(order));
-
-        // when
-        CookTimeResponse response = ownerOrderService.setCookTime(orderId, cookTime);
-
-        // then
-        assertThat(response.getOrderId()).isEqualTo(orderId);
-        assertThat(response.getDeliveryEta()).isNotNull();
-
-        // 시간 포맷만 검증
-        assertThat(response.getDeliveryEta()).matches("\\d{2}\\.\\d{2} \\d{2}:\\d{2}");
-    }
-
-    @Test
-    @DisplayName("주문이 없으면 예외 발생")
+    @DisplayName("예상 조리시간 설정 시 주문이 없으면 예외 발생")
     void setCookTime_orderNotFound() {
         // given
         Long orderId = 99L;
@@ -230,38 +208,58 @@ class OwnerOrderServiceTest {
     }
 
     @Test
-    @DisplayName("예상 조리 시간 설정 실패 - 상태 COMPLETED일 경우")
+    @DisplayName("예상 조리 시간 설정 성공 - ACCEPTED 상태에서 COOKING 전이 가능")
+    void setCookTime_success() {
+        // given
+        Long orderId = 1L;
+        int cookTime = 15;
+        Order order = Order.builder()
+                .orderId(orderId)
+                .orderStatus(OrderStatus.ACCEPTED) // COOKING 전이 가능 상태
+                .build();
+        given(orderRepository.findById(orderId)).willReturn(Optional.of(order));
+
+        // when
+        CookTimeResponse response = ownerOrderService.setCookTime(orderId, cookTime);
+
+        // then
+        assertThat(response.getOrderId()).isEqualTo(orderId);
+        assertThat(response.getDeliveryEta()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("예상 조리 시간 설정 실패 - COMPLETED 상태에서 COOKING 전이 불가")
     void setCookTime_fail_status_completed() {
         // given
         Long orderId = 1L;
         int cookTime = 15;
         Order order = Order.builder()
                 .orderId(orderId)
-                .orderStatus(OrderStatus.COMPLETED)
+                .orderStatus(OrderStatus.COMPLETED) // COOKING 전이 불가 상태
                 .build();
         given(orderRepository.findById(orderId)).willReturn(Optional.of(order));
 
         // when & then
         assertThatThrownBy(() -> ownerOrderService.setCookTime(orderId, cookTime))
                 .isInstanceOf(OrderException.class)
-                .hasMessage(OrderErrorCode.INVALID_ORDER_STATUS.getMessage());
+                .hasMessage(OrderErrorCode.ORDER_STATUS_UPDATE_FAIL.getMessage());
     }
 
     @Test
-    @DisplayName("예상 조리 시간 설정 실패 - 상태 REJECTED일 경우")
+    @DisplayName("예상 조리 시간 설정 실패 - REJECTED 상태에서 COOKING 전이 불가")
     void setCookTime_fail_status_rejected() {
         // given
         Long orderId = 1L;
         int cookTime = 15;
         Order order = Order.builder()
                 .orderId(orderId)
-                .orderStatus(OrderStatus.REJECTED)
+                .orderStatus(OrderStatus.REJECTED) // COOKING 전이 불가 상태
                 .build();
         given(orderRepository.findById(orderId)).willReturn(Optional.of(order));
 
         // when & then
         assertThatThrownBy(() -> ownerOrderService.setCookTime(orderId, cookTime))
                 .isInstanceOf(OrderException.class)
-                .hasMessage(OrderErrorCode.INVALID_ORDER_STATUS.getMessage());
+                .hasMessage(OrderErrorCode.ORDER_STATUS_UPDATE_FAIL.getMessage());
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈
#159 

## 📝작업 내용

- [ ] `CookTimeRequest`, `CookTimeResponse` dto 작성
- [ ] `OwnerOrderService`, `OwnerOrderController` 에 조리시간 설정 메서드 작성
- [ ] 테스트 코드 작성 완료 후 작동 확인 완료

### 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/fb934329-542c-43f1-a519-87160a5fe084)
![image](https://github.com/user-attachments/assets/aedf0e98-29ed-441b-bad0-adfb3176b299)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 주문의 예상 조리시간을 설정할 수 있는 엔드포인트가 추가되었습니다.
  * 예상 조리시간 입력 시, 주문의 배달 예상 도착 시간이 자동으로 계산되어 응답에 포함됩니다.

* **버그 수정**
  * 없음

* **테스트**
  * 예상 조리시간 설정 기능에 대한 성공 및 실패 케이스 테스트가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->