### PR TITLE
[Feature] 과거 주문 내역 조회 API 구현

### DIFF
--- a/src/main/java/com/idukbaduk/itseats/order/controller/OrderController.java
+++ b/src/main/java/com/idukbaduk/itseats/order/controller/OrderController.java
@@ -5,15 +5,12 @@ import com.idukbaduk.itseats.order.dto.OrderNewRequest;
 import com.idukbaduk.itseats.order.dto.enums.OrderResponse;
 import com.idukbaduk.itseats.order.service.OrderService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/orders")
@@ -29,6 +26,18 @@ public class OrderController {
         return BaseResponse.toResponseEntity(
                 OrderResponse.GET_ORDER_DETAILS_SUCCESS,
                 orderService.getOrderNew(userDetails.getUsername(), orderNewRequest)
+        );
+    }
+
+    @GetMapping
+    public ResponseEntity<BaseResponse> getOrders(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @RequestParam(defaultValue = "") String keyword,
+            @PageableDefault(page = 0, size = 20) Pageable pageable
+    ) {
+        return BaseResponse.toResponseEntity(
+                OrderResponse.GET_ORDERS_SUCCESS,
+                orderService.getOrders(userDetails.getUsername(), keyword, pageable)
         );
     }
 

--- a/src/main/java/com/idukbaduk/itseats/order/dto/OrderHistoryDto.java
+++ b/src/main/java/com/idukbaduk/itseats/order/dto/OrderHistoryDto.java
@@ -1,0 +1,43 @@
+package com.idukbaduk.itseats.order.dto;
+
+import com.idukbaduk.itseats.order.entity.Order;
+import com.idukbaduk.itseats.order.entity.OrderMenu;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.stream.Collectors;
+
+@Getter
+@Builder
+public class OrderHistoryDto {
+    Long orderId;
+    Long storeId;
+    String orderNumber;
+    String storeName;
+    LocalDateTime createdAt;
+    String status;
+    Integer orderPrice;
+    String deliveryAddress;
+    String deliveryRequest;
+    String menuSummary;
+
+    public static OrderHistoryDto of(Order order) {
+        return builder()
+                .orderId(order.getOrderId())
+                .storeId(order.getStore().getStoreId())
+                .orderNumber(order.getOrderNumber())
+                .storeName(order.getStore().getStoreName())
+                .createdAt(order.getCreatedAt())
+                .status(order.getOrderStatus().toString())
+                .orderPrice(order.getOrderPrice())
+                .deliveryAddress(order.getDeliveryAddress())
+                .deliveryRequest("구현 예정")
+                .menuSummary(
+                        order.getOrderMenus().stream()
+                                .map(OrderMenu::getMenuName)
+                                .collect(Collectors.joining(", "))
+                )
+                .build();
+    }
+}

--- a/src/main/java/com/idukbaduk/itseats/order/dto/OrderHistoryResponse.java
+++ b/src/main/java/com/idukbaduk/itseats/order/dto/OrderHistoryResponse.java
@@ -1,0 +1,13 @@
+package com.idukbaduk.itseats.order.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class OrderHistoryResponse {
+    List<OrderHistoryDto> orders;
+    Boolean hasNext;
+}

--- a/src/main/java/com/idukbaduk/itseats/order/dto/enums/OrderResponse.java
+++ b/src/main/java/com/idukbaduk/itseats/order/dto/enums/OrderResponse.java
@@ -7,6 +7,7 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum OrderResponse implements Response {
 
+    GET_ORDERS_SUCCESS(HttpStatus.OK, "과거 주문 내역 조회 성공"),
     GET_ORDER_DETAILS_SUCCESS(HttpStatus.OK, "주문 정보 상세 조회 성공"),
     GET_ORDER_STATUS_SUCCESS(HttpStatus.OK, "주문 현황 조회 성공"),
     GET_STORE_ORDERS_SUCCESS(HttpStatus.OK, "주문 접수 조회 성공"),

--- a/src/main/java/com/idukbaduk/itseats/order/repository/OrderRepository.java
+++ b/src/main/java/com/idukbaduk/itseats/order/repository/OrderRepository.java
@@ -3,6 +3,9 @@ package com.idukbaduk.itseats.order.repository;
 import com.idukbaduk.itseats.member.entity.Member;
 import com.idukbaduk.itseats.order.entity.Order;
 import com.idukbaduk.itseats.rider.entity.Rider;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -113,4 +116,21 @@ public interface OrderRepository extends JpaRepository<Order, Long> {
             @Param("riderLat") double riderLat,
             @Param("riderLng") double riderLng
     );
+
+    @EntityGraph(attributePaths = {"orderMenus", "store"})
+    @Query("""
+        SELECT o
+        FROM Order o
+        WHERE o.member.username = :username
+          AND (
+            :keyword = '' OR
+            EXISTS (
+              SELECT 1 FROM OrderMenu om
+              WHERE om.order = o AND om.menuName LIKE %:keyword%
+            ) OR
+            o.store.storeName LIKE %:keyword%
+          )
+        ORDER BY o.createdAt DESC
+    """)
+    Slice<Order> findOrdersByUsernameWithKeyword(String username, String keyword, Pageable pageable);
 }

--- a/src/main/java/com/idukbaduk/itseats/order/service/OrderService.java
+++ b/src/main/java/com/idukbaduk/itseats/order/service/OrderService.java
@@ -5,23 +5,15 @@ import com.idukbaduk.itseats.member.entity.Member;
 import com.idukbaduk.itseats.member.error.MemberException;
 import com.idukbaduk.itseats.member.error.enums.MemberErrorCode;
 import com.idukbaduk.itseats.member.repository.MemberRepository;
-import com.idukbaduk.itseats.member.service.MemberService;
 import com.idukbaduk.itseats.memberaddress.entity.MemberAddress;
 import com.idukbaduk.itseats.memberaddress.error.MemberAddressException;
 import com.idukbaduk.itseats.memberaddress.error.enums.MemberAddressErrorCode;
 import com.idukbaduk.itseats.memberaddress.repository.MemberAddressRepository;
-import com.idukbaduk.itseats.memberaddress.service.MemberAddressService;
 import com.idukbaduk.itseats.menu.entity.Menu;
 import com.idukbaduk.itseats.menu.error.MenuErrorCode;
 import com.idukbaduk.itseats.menu.error.MenuException;
 import com.idukbaduk.itseats.menu.repository.MenuRepository;
-import com.idukbaduk.itseats.menu.service.MenuService;
-import com.idukbaduk.itseats.order.dto.AddressInfoDTO;
-import com.idukbaduk.itseats.order.dto.MenuOptionDTO;
-import com.idukbaduk.itseats.order.dto.OrderMenuDTO;
-import com.idukbaduk.itseats.order.dto.OrderNewRequest;
-import com.idukbaduk.itseats.order.dto.OrderNewResponse;
-import com.idukbaduk.itseats.order.dto.OrderStatusResponse;
+import com.idukbaduk.itseats.order.dto.*;
 import com.idukbaduk.itseats.order.entity.Order;
 import com.idukbaduk.itseats.order.entity.OrderMenu;
 import com.idukbaduk.itseats.order.entity.enums.OrderStatus;
@@ -34,13 +26,13 @@ import com.idukbaduk.itseats.payment.entity.Payment;
 import com.idukbaduk.itseats.payment.error.PaymentException;
 import com.idukbaduk.itseats.payment.error.enums.PaymentErrorCode;
 import com.idukbaduk.itseats.payment.repository.PaymentRepository;
-import com.idukbaduk.itseats.payment.service.PaymentService;
 import com.idukbaduk.itseats.store.entity.Store;
 import com.idukbaduk.itseats.store.error.StoreException;
 import com.idukbaduk.itseats.store.error.enums.StoreErrorCode;
 import com.idukbaduk.itseats.store.repository.StoreRepository;
-import com.idukbaduk.itseats.store.service.StoreService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -160,6 +152,15 @@ public class OrderService {
         } catch (Exception e) {
             throw new OrderException(OrderErrorCode.MENU_OPTION_SERIALIZATION_FAIL);
         }
+    }
+
+    @Transactional
+    public OrderHistoryResponse getOrders(String username, String keyword, Pageable pageable) {
+        Slice<Order> orders = orderRepository.findOrdersByUsernameWithKeyword(username, keyword, pageable);
+        return OrderHistoryResponse.builder()
+                .orders(orders.stream().map(OrderHistoryDto::of).toList())
+                .hasNext(orders.hasNext())
+                .build();
     }
 
     @Transactional(readOnly = true)

--- a/src/test/java/com/idukbaduk/itseats/order/service/OrderServiceTest.java
+++ b/src/test/java/com/idukbaduk/itseats/order/service/OrderServiceTest.java
@@ -8,14 +8,9 @@ import com.idukbaduk.itseats.memberaddress.entity.MemberAddress;
 import com.idukbaduk.itseats.memberaddress.repository.MemberAddressRepository;
 import com.idukbaduk.itseats.menu.entity.Menu;
 import com.idukbaduk.itseats.menu.repository.MenuRepository;
-import com.idukbaduk.itseats.order.dto.AddressInfoDTO;
-import com.idukbaduk.itseats.order.dto.MenuOptionDTO;
-import com.idukbaduk.itseats.order.dto.OptionDTO;
-import com.idukbaduk.itseats.order.dto.OrderMenuDTO;
-import com.idukbaduk.itseats.order.dto.OrderNewRequest;
-import com.idukbaduk.itseats.order.dto.OrderNewResponse;
-import com.idukbaduk.itseats.order.dto.OrderStatusResponse;
+import com.idukbaduk.itseats.order.dto.*;
 import com.idukbaduk.itseats.order.entity.Order;
+import com.idukbaduk.itseats.order.entity.OrderMenu;
 import com.idukbaduk.itseats.order.entity.enums.DeliveryType;
 import com.idukbaduk.itseats.order.entity.enums.OrderStatus;
 import com.idukbaduk.itseats.order.error.OrderException;
@@ -34,6 +29,9 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.*;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.locationtech.jts.geom.Point;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -41,6 +39,7 @@ import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.groups.Tuple.tuple;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
@@ -287,5 +286,37 @@ class OrderServiceTest {
         assertThatThrownBy(() -> orderService.getOrder(1L))
                 .isInstanceOf(OrderException.class)
                 .hasMessageContaining(OrderErrorCode.ORDER_NOT_FOUND.getMessage());
+    }
+    
+    @Test
+    @DisplayName("과거 주문내역 조회 성공")
+    void getOrders_success() {
+        // given
+        PageRequest pageRequest = PageRequest.of(0, 1);
+        List<OrderMenu> orderMenuList = List.of(
+                OrderMenu.builder().menuName("양념치킨").build(),
+                OrderMenu.builder().menuName("간장치킨").build()
+        );
+        List<Order> orderList = List.of(
+                Order.builder()
+                        .orderId(1L)
+                        .store(Store.builder().storeId(1L).storeName("치킨집").build())
+                        .orderStatus(OrderStatus.COOKING)
+                        .orderMenus(orderMenuList)
+                        .build()
+        );
+        Slice<Order> orders = new SliceImpl<Order>(orderList, pageRequest, true);
+
+        when(orderRepository.findOrdersByUsernameWithKeyword(anyString(), anyString(), eq(pageRequest)))
+                .thenReturn(orders);
+    
+        // when
+        OrderHistoryResponse data = orderService.getOrders("username", "keyword", pageRequest);
+
+        // then
+        assertThat(data).isNotNull();
+        assertThat(data.getOrders()).hasSize(1)
+                .extracting("orderId", "storeId", "storeName", "status", "menuSummary")
+                .containsExactly(tuple(1L, 1L, "치킨집", "COOKING", "양념치킨, 간장치킨"));
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

#167
closes #167

## 📝작업 내용

과거 주문 내역을 조회할 수 있다.
매장명과 메뉴명을 이용하여 검색할 수 있다.

Pageable과 Slice<Order>로 조회하여 Pagination 적용

- [x] Repository 쿼리 작성
- [x] Service 작성
- [x] Controller 작성
- [x] 테스트 코드 작성

### 스크린샷 (선택)

<details>
    <summary>열기</summary>

![요청 성공 스크린샷](https://github.com/user-attachments/assets/28cb6450-b257-4c38-920d-715ae7962ba7)

</details>
