### PR TITLE
[Refactor] 가게 목록 조회 API 리팩터링

### DIFF
--- a/src/main/java/com/idukbaduk/itseats/global/util/GeoUtil.java
+++ b/src/main/java/com/idukbaduk/itseats/global/util/GeoUtil.java
@@ -17,4 +17,14 @@ public class GeoUtil {
     public static Point toPoint(double lng, double lat) {
         return geometryFactory.createPoint(new Coordinate(lng, lat));
     }
+
+
+    /**
+     * Point 객체를 문자열로 변환합니다. (예시: "POINT(127.0276 37.4979)")
+     * @param point 객체
+     * @return String 문자열
+     */
+    public static String toString(Point point) {
+        return "POINT(" + point.getX() + " " + point.getY() + ")";
+    }
 }

--- a/src/main/java/com/idukbaduk/itseats/store/controller/StoreController.java
+++ b/src/main/java/com/idukbaduk/itseats/store/controller/StoreController.java
@@ -20,10 +20,10 @@ public class StoreController {
     private final StoreService storeService;
 
     @GetMapping("/list")
-    public ResponseEntity<BaseResponse> getAllStores() {
+    public ResponseEntity<BaseResponse> getAllStores(@PageableDefault Pageable pageable) {
         return BaseResponse.toResponseEntity(
                 StoreResponse.GET_STORES_SUCCESS,
-                storeService.getAllStores()
+                storeService.getAllStores(pageable)
         );
     }
 
@@ -44,7 +44,7 @@ public class StoreController {
             @PathVariable String storeCategory,
             @PageableDefault Pageable pageable,
             @RequestParam(defaultValue = "ORDER_COUNT") StoreSortOption sort,
-            @RequestParam Long addressId
+            @RequestParam(required = false) Long addressId
             ) {
         return BaseResponse.toResponseEntity(
                 StoreResponse.GET_STORES_BY_CATEGORY_SUCCESS,

--- a/src/main/java/com/idukbaduk/itseats/store/controller/StoreController.java
+++ b/src/main/java/com/idukbaduk/itseats/store/controller/StoreController.java
@@ -1,21 +1,16 @@
 package com.idukbaduk.itseats.store.controller;
 
 import com.idukbaduk.itseats.global.response.BaseResponse;
-import com.idukbaduk.itseats.member.entity.Member;
-import com.idukbaduk.itseats.store.dto.StoreDetailResponse;
-import com.idukbaduk.itseats.store.dto.StoreCategoryListResponse;
-import com.idukbaduk.itseats.store.dto.StoreListResponse;
 import com.idukbaduk.itseats.store.dto.enums.StoreResponse;
+import com.idukbaduk.itseats.store.dto.enums.StoreSortOption;
 import com.idukbaduk.itseats.store.service.StoreService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -44,10 +39,21 @@ public class StoreController {
     }
 
     @GetMapping("/list/{storeCategory}")
-    public ResponseEntity<BaseResponse> getStoresByCategory(@PathVariable String storeCategory) {
+    public ResponseEntity<BaseResponse> getStoresByCategory(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @PathVariable String storeCategory,
+            @PageableDefault Pageable pageable,
+            @RequestParam(defaultValue = "ORDER_COUNT") StoreSortOption sort,
+            @RequestParam Long addressId
+            ) {
         return BaseResponse.toResponseEntity(
                 StoreResponse.GET_STORES_BY_CATEGORY_SUCCESS,
-                storeService.getStoresByCategory(storeCategory)
+                storeService.getStoresByCategory(
+                        (userDetails == null ? "test" : userDetails.getUsername()),
+                        storeCategory, pageable,
+                        sort,
+                        addressId
+                )
         );
     }
 }

--- a/src/main/java/com/idukbaduk/itseats/store/controller/StoreController.java
+++ b/src/main/java/com/idukbaduk/itseats/store/controller/StoreController.java
@@ -49,7 +49,7 @@ public class StoreController {
         return BaseResponse.toResponseEntity(
                 StoreResponse.GET_STORES_BY_CATEGORY_SUCCESS,
                 storeService.getStoresByCategory(
-                        (userDetails == null ? "test" : userDetails.getUsername()),
+                        (userDetails == null ? null : userDetails.getUsername()),
                         storeCategory, pageable,
                         sort,
                         addressId

--- a/src/main/java/com/idukbaduk/itseats/store/controller/StoreController.java
+++ b/src/main/java/com/idukbaduk/itseats/store/controller/StoreController.java
@@ -5,6 +5,7 @@ import com.idukbaduk.itseats.member.entity.Member;
 import com.idukbaduk.itseats.store.dto.StoreDetailResponse;
 import com.idukbaduk.itseats.store.dto.StoreCategoryListResponse;
 import com.idukbaduk.itseats.store.dto.StoreListResponse;
+import com.idukbaduk.itseats.store.dto.enums.StoreResponse;
 import com.idukbaduk.itseats.store.service.StoreService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -25,8 +26,10 @@ public class StoreController {
 
     @GetMapping("/list")
     public ResponseEntity<BaseResponse> getAllStores() {
-        StoreListResponse response = storeService.getAllStores();
-        return BaseResponse.toResponseEntity(HttpStatus.OK, "전체 가게 목록 조회 성공", response);
+        return BaseResponse.toResponseEntity(
+                StoreResponse.GET_STORES_SUCCESS,
+                storeService.getAllStores()
+        );
     }
 
     @GetMapping("/{storeId}")
@@ -34,13 +37,17 @@ public class StoreController {
             @PathVariable Long storeId,
             @AuthenticationPrincipal UserDetails userDetails
             ) {
-        StoreDetailResponse response = storeService.getStoreDetail(userDetails.getUsername(), storeId);
-        return BaseResponse.toResponseEntity(HttpStatus.OK, "가게 상세 조회 성공", response);
+        return BaseResponse.toResponseEntity(
+                StoreResponse.GET_STORE_DETAIL_SUCCESS,
+                storeService.getStoreDetail(userDetails.getUsername(), storeId)
+        );
     }
 
     @GetMapping("/list/{storeCategory}")
     public ResponseEntity<BaseResponse> getStoresByCategory(@PathVariable String storeCategory) {
-        StoreCategoryListResponse response = storeService.getStoresByCategory(storeCategory);
-        return BaseResponse.toResponseEntity(HttpStatus.OK, "카테고리 별 가게 목록 조회 성공", response);
+        return BaseResponse.toResponseEntity(
+                StoreResponse.GET_STORES_BY_CATEGORY_SUCCESS,
+                storeService.getStoresByCategory(storeCategory)
+        );
     }
 }

--- a/src/main/java/com/idukbaduk/itseats/store/dto/StoreCategoryListResponse.java
+++ b/src/main/java/com/idukbaduk/itseats/store/dto/StoreCategoryListResponse.java
@@ -11,4 +11,6 @@ public class StoreCategoryListResponse {
     private String category;
     private String categoryName;
     private List<StoreDto> stores;
+    private Integer currentPage;
+    private Boolean hasNext;
 }

--- a/src/main/java/com/idukbaduk/itseats/store/dto/StoreListResponse.java
+++ b/src/main/java/com/idukbaduk/itseats/store/dto/StoreListResponse.java
@@ -9,4 +9,6 @@ import java.util.List;
 @Builder
 public class StoreListResponse {
     private List<StoreDto> stores;
+    private Integer currentPage;
+    private Boolean hasNext;
 }

--- a/src/main/java/com/idukbaduk/itseats/store/dto/enums/StoreResponse.java
+++ b/src/main/java/com/idukbaduk/itseats/store/dto/enums/StoreResponse.java
@@ -9,7 +9,10 @@ public enum StoreResponse implements Response {
 
     CREATE_STORE_SUCCESS(HttpStatus.CREATED, "가게 추가 성공"),
     UPDATE_STATUS_SUCCESS(HttpStatus.OK, "가게 상태 변경 성공"),
-    PAUSE_ORDER_SUCCESS(HttpStatus.OK, "주문 일시정지 성공")
+    PAUSE_ORDER_SUCCESS(HttpStatus.OK, "주문 일시정지 성공"),
+    GET_STORES_SUCCESS(HttpStatus.OK, "전체 가게 목록 조회 성공"),
+    GET_STORES_BY_CATEGORY_SUCCESS(HttpStatus.OK, "카테고리 별 가게 목록 조회 성공"),
+    GET_STORE_DETAIL_SUCCESS(HttpStatus.OK, "가게 상세 조회 성공"),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/idukbaduk/itseats/store/dto/enums/StoreSortOption.java
+++ b/src/main/java/com/idukbaduk/itseats/store/dto/enums/StoreSortOption.java
@@ -1,0 +1,8 @@
+package com.idukbaduk.itseats.store.dto.enums;
+
+public enum StoreSortOption {
+    DISTANCE,               // 거리순
+    RATING,                 // 별점순
+    ORDER_COUNT,           // 주문 많은 순
+    RECENT;                 // 최신 등록순
+}

--- a/src/main/java/com/idukbaduk/itseats/store/repository/StoreRepository.java
+++ b/src/main/java/com/idukbaduk/itseats/store/repository/StoreRepository.java
@@ -31,4 +31,14 @@ public interface StoreRepository extends JpaRepository<Store, Long> {
         ORDER BY ST_Distance_Sphere(location, ST_GeomFromText(:myLocation, 4326))
     """, nativeQuery = true)
     Slice<Store> findNearByStoresByCategory(Long storeCategoryId, String myLocation, Pageable pageable);
+
+    @Query(value = """
+        SELECT s.* FROM store s
+        LEFT JOIN review r ON r.store_id = s.store_id
+        WHERE s.store_category_id = :storeCategoryId
+          AND s.is_deleted = 0
+        GROUP BY s.store_id
+        ORDER BY AVG(IFNULL(r.store_star, 0)) DESC
+    """, nativeQuery = true)
+    Slice<Store> findStoresOrderByRating(Long storeCategoryId, Pageable pageable);
 }

--- a/src/main/java/com/idukbaduk/itseats/store/repository/StoreRepository.java
+++ b/src/main/java/com/idukbaduk/itseats/store/repository/StoreRepository.java
@@ -51,4 +51,12 @@ public interface StoreRepository extends JpaRepository<Store, Long> {
         ORDER BY COUNT(o.order_id) DESC
     """, nativeQuery = true)
     Slice<Store> findStoresOrderByOrderCount(Long storeCategoryId, Pageable pageable);
+
+    @Query(value = """
+        SELECT * FROM store
+        WHERE store_category_id = :storeCategoryId
+            AND is_deleted = 0
+        ORDER BY created_at DESC
+    """, nativeQuery = true)
+    Slice<Store> findStoresOrderByCreatedAt(Long storeCategoryId, Pageable pageable);
 }

--- a/src/main/java/com/idukbaduk/itseats/store/repository/StoreRepository.java
+++ b/src/main/java/com/idukbaduk/itseats/store/repository/StoreRepository.java
@@ -2,7 +2,12 @@ package com.idukbaduk.itseats.store.repository;
 
 import com.idukbaduk.itseats.member.entity.Member;
 import com.idukbaduk.itseats.store.entity.Store;
+import com.idukbaduk.itseats.store.entity.StoreCategory;
+import org.locationtech.jts.geom.Point;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -18,4 +23,12 @@ public interface StoreRepository extends JpaRepository<Store, Long> {
     Optional<Store> findByStoreIdAndDeletedFalse(Long storeId);
   
     List<Store> findAllByStoreCategory_CategoryCodeAndDeletedFalse(String categoryCode);
+
+    @Query(value = """
+        SELECT * FROM store
+        WHERE store_category_id = :storeCategoryId
+        AND is_deleted = 0
+        ORDER BY ST_Distance_Sphere(location, ST_GeomFromText(:myLocation, 4326))
+    """, nativeQuery = true)
+    Slice<Store> findNearByStoresByCategory(Long storeCategoryId, String myLocation, Pageable pageable);
 }

--- a/src/main/java/com/idukbaduk/itseats/store/repository/StoreRepository.java
+++ b/src/main/java/com/idukbaduk/itseats/store/repository/StoreRepository.java
@@ -41,4 +41,14 @@ public interface StoreRepository extends JpaRepository<Store, Long> {
         ORDER BY AVG(IFNULL(r.store_star, 0)) DESC
     """, nativeQuery = true)
     Slice<Store> findStoresOrderByRating(Long storeCategoryId, Pageable pageable);
+
+    @Query(value = """
+        SELECT s.* FROM store s 
+        LEFT JOIN orders o ON o.store_id = s.store_id
+        WHERE s.store_category_id = :storeCategoryId
+            AND s.is_deleted = 0
+        GROUP BY s.store_id
+        ORDER BY COUNT(o.order_id) DESC
+    """, nativeQuery = true)
+    Slice<Store> findStoresOrderByOrderCount(Long storeCategoryId, Pageable pageable);
 }

--- a/src/main/java/com/idukbaduk/itseats/store/repository/StoreRepository.java
+++ b/src/main/java/com/idukbaduk/itseats/store/repository/StoreRepository.java
@@ -25,6 +25,15 @@ public interface StoreRepository extends JpaRepository<Store, Long> {
     List<Store> findAllByStoreCategory_CategoryCodeAndDeletedFalse(String categoryCode);
 
     @Query(value = """
+        SELECT s.* FROM store s 
+        LEFT JOIN orders o ON o.store_id = s.store_id
+        WHERE s.is_deleted = 0
+        GROUP BY s.store_id
+        ORDER BY COUNT(o.order_id) DESC
+    """, nativeQuery = true)
+    Slice<Store> findAllOrderByOrderCount(Pageable pageable);
+
+    @Query(value = """
         SELECT * FROM store
         WHERE store_category_id = :storeCategoryId
         AND is_deleted = 0

--- a/src/main/java/com/idukbaduk/itseats/store/service/StoreService.java
+++ b/src/main/java/com/idukbaduk/itseats/store/service/StoreService.java
@@ -86,6 +86,7 @@ public class StoreService {
                 .orElseThrow(() -> new StoreException(StoreErrorCode.CATEGORY_NOT_FOUND));
 
         Slice<Store> stores = null;
+        PageRequest pageRequest = PageRequest.of(pageable.getPageNumber(), pageable.getPageSize(), Sort.unsorted()); // 기본 정렬 무시
         if (sort == StoreSortOption.DISTANCE) {
             Member member = memberRepository.findByUsername(username).orElse(null);
             Point myLocation = Optional.ofNullable(member)
@@ -94,12 +95,14 @@ public class StoreService {
                             .getLocation())
                     .orElse(GeoUtil.toPoint(126.9779451, 37.5662952)); // 서울시청 (기본값)
 
-            PageRequest pageRequest = PageRequest.of(pageable.getPageNumber(), pageable.getPageSize(), Sort.unsorted()); // 기본 정렬 무시
             stores = storeRepository.findNearByStoresByCategory(
                     category.getStoreCategoryId(),
                     GeoUtil.toString(myLocation),
                     pageRequest
             );
+        }
+        else if (sort == StoreSortOption.RATING) {
+            stores = storeRepository.findStoresOrderByRating(category.getStoreCategoryId(), pageRequest);
         }
 
         if (stores == null || stores.getContent().isEmpty()) {

--- a/src/main/java/com/idukbaduk/itseats/store/service/StoreService.java
+++ b/src/main/java/com/idukbaduk/itseats/store/service/StoreService.java
@@ -104,6 +104,9 @@ public class StoreService {
         else if (sort == StoreSortOption.RATING) {
             stores = storeRepository.findStoresOrderByRating(category.getStoreCategoryId(), pageRequest);
         }
+        else if (sort == StoreSortOption.ORDER_COUNT) {
+            stores = storeRepository.findStoresOrderByOrderCount(category.getStoreCategoryId(), pageRequest);
+        }
 
         if (stores == null || stores.getContent().isEmpty()) {
             return StoreCategoryListResponse.builder()

--- a/src/main/java/com/idukbaduk/itseats/store/service/StoreService.java
+++ b/src/main/java/com/idukbaduk/itseats/store/service/StoreService.java
@@ -107,6 +107,9 @@ public class StoreService {
         else if (sort == StoreSortOption.ORDER_COUNT) {
             stores = storeRepository.findStoresOrderByOrderCount(category.getStoreCategoryId(), pageRequest);
         }
+        else if (sort == StoreSortOption.RECENT) {
+            stores = storeRepository.findStoresOrderByCreatedAt(category.getStoreCategoryId(), pageRequest);
+        }
 
         if (stores == null || stores.getContent().isEmpty()) {
             return StoreCategoryListResponse.builder()

--- a/src/test/java/com/idukbaduk/itseats/store/service/StoreServiceTest.java
+++ b/src/test/java/com/idukbaduk/itseats/store/service/StoreServiceTest.java
@@ -116,8 +116,8 @@ class StoreServiceTest {
         StoreImage image2 = StoreImage.builder().store(store2).imageUrl("s3 url 2").build();
         StoreImage image3 = StoreImage.builder().store(store3).imageUrl("s3 url 3").build();
 
-        when(storeRepository.findAllByDeletedFalse())
-                .thenReturn(List.of(store1, store2, store3));
+        when(storeRepository.findAllOrderByOrderCount(any(Pageable.class)))
+                .thenReturn(new SliceImpl<>(List.of(store1, store2, store3)));
         when(storeImageRepository.findImagesByStoreIds(List.of(1L, 2L, 3L)))
                 .thenReturn(List.of(image1, image2, image3));
         when(reviewRepository.findReviewStatsByStoreIds(List.of(1L, 2L, 3L)))
@@ -126,9 +126,10 @@ class StoreServiceTest {
                         new Object[]{2L, 4.7, 2847L},
                         new Object[]{3L, 4.5, 3715L}
                 ));
+        PageRequest pageRequest = PageRequest.of(0, 10);
 
         // when
-        StoreListResponse response = storeService.getAllStores();
+        StoreListResponse response = storeService.getAllStores(pageRequest);
 
         // then
         assertThat(response).isNotNull();
@@ -163,12 +164,13 @@ class StoreServiceTest {
         Store store1 = Store.builder().storeId(1L).storeName("신규 가게").build();
         StoreImage image1 = StoreImage.builder().store(store1).imageUrl("s3 url").build();
 
-        when(storeRepository.findAllByDeletedFalse()).thenReturn(List.of(store1));
+        when(storeRepository.findAllOrderByOrderCount(any(Pageable.class))).thenReturn(new SliceImpl<>(List.of(store1)));
         when(storeImageRepository.findImagesByStoreIds(List.of(1L))).thenReturn(List.of(image1));
         when(reviewRepository.findReviewStatsByStoreIds(List.of(1L))).thenReturn(Collections.emptyList());
+        PageRequest pageRequest = PageRequest.of(0, 10);
 
         // when
-        StoreListResponse response = storeService.getAllStores();
+        StoreListResponse response = storeService.getAllStores(pageRequest);
 
         // then
         assertThat(response).isNotNull();
@@ -186,10 +188,11 @@ class StoreServiceTest {
     @DisplayName("가게가 없을 때 빈 리스트 반환")
     void getAllStores_emptyList_returnsEmptyList() {
         // given
-        when(storeRepository.findAllByDeletedFalse()).thenReturn(Collections.emptyList());
+        PageRequest pageRequest = PageRequest.of(0, 10);
+        when(storeRepository.findAllOrderByOrderCount(pageRequest)).thenReturn(new SliceImpl<>(Collections.emptyList()));
 
         // when
-        StoreListResponse response = storeService.getAllStores();
+        StoreListResponse response = storeService.getAllStores(pageRequest);
 
         // then
         assertThat(response).isNotNull();


### PR DESCRIPTION
## #️⃣연관된 이슈

#172
closes #172

## 📝작업 내용

가게 목록 조회 API를 리팩터링합니다. `Slice`를 이용하여 조회시 전체 count 쿼리 호출을 없앱니다. 그리고 가까운 순 조회 등 정렬 기능을 제공합니다.

- [x] `Slice` 자료형 조회 및 DTO 개선
- [x] 주문 많은 순 정렬
- [x] 가까운 순 정렬
- [x] 리뷰 평점 순 정렬
- [x] 최근 순 정렬  

### 스크린샷 (선택)

<details>
  <summary>열기</summary>
  ![image](https://github.com/user-attachments/assets/586bee1f-0113-4e6e-9dd7-0e836e79f1cf)
</details>

## 💬리뷰 요구사항(선택)

ST_ 로 시작하는 공간 관련 MySQL 함수를 쓸 때는 Point를 다시 문자열로 바꿔서 넣어야 하더라고요. 문자열로 바꾸는 함수를 `GeoUtil` 클래스에 쓸 수 있게 만들어 놓았습니다.

특별한 이유가 없다면 프론트엔드 연동 작업 후 머지하도록 하겠습니다!
