### PR TITLE
refactor: 메뉴 옵션 조회 엔드포인트 변경

### DIFF
--- a/src/main/java/com/idukbaduk/itseats/menu/controller/UserMenuController.java
+++ b/src/main/java/com/idukbaduk/itseats/menu/controller/UserMenuController.java
@@ -19,7 +19,7 @@ public class UserMenuController {
 
     private final UserMenuService userMenuService;
 
-    @GetMapping("/{storeId}/{menuId}/options")
+    @GetMapping("/{storeId}/menus/{menuId}/options")
     public ResponseEntity<BaseResponse> getMenuOptions(
             @PathVariable Long storeId,
             @PathVariable Long menuId


### PR DESCRIPTION
## #️⃣연관된 이슈

#178
closes #178

## 📝작업 내용

메뉴 옵션 조회를 위한 URL을 `/api/stores/{storeId}/{menuId}/options`에서 `/api/stores/{storeId}/menus/{menuId}/options`으로 변경합니다.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * 메뉴 옵션 조회를 위한 URL 경로가 `/{storeId}/{menuId}/options`에서 `/{storeId}/menus/{menuId}/options`로 변경되었습니다.  
  (이로 인해 메뉴 옵션 조회 시 기존 URL 대신 새로운 경로를 사용해야 합니다.)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->