### PR TITLE
chore: access-token 헤더 CORS 설정

### DIFF
--- a/src/main/java/com/idukbaduk/itseats/global/config/CorsConfig.java
+++ b/src/main/java/com/idukbaduk/itseats/global/config/CorsConfig.java
@@ -21,7 +21,7 @@ public class CorsConfig {
         config.setAllowedHeaders(List.of("*"));
         config.setAllowCredentials(true);
 
-        config.setExposedHeaders(List.of("access-token"));
+        config.setExposedHeaders(List.of("access-token", "Access-Token"));
 
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
         source.registerCorsConfiguration("/**", config);

--- a/src/main/java/com/idukbaduk/itseats/global/config/CorsConfig.java
+++ b/src/main/java/com/idukbaduk/itseats/global/config/CorsConfig.java
@@ -21,6 +21,8 @@ public class CorsConfig {
         config.setAllowedHeaders(List.of("*"));
         config.setAllowCredentials(true);
 
+        config.setExposedHeaders(List.of("access-token"));
+
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
         source.registerCorsConfiguration("/**", config);
         return source;


### PR DESCRIPTION
## #️⃣연관된 이슈

#182
closes #182

## 📝작업 내용

브라우저에서 access-token 헤더를 사용할 수 있도록 CORS 설정을 변경합니다.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


* **버그 수정**
  * 클라이언트에서 "access-token" 및 "Access-Token" 헤더를 명시적으로 확인할 수 있도록 CORS 설정이 업데이트되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->