### PR TITLE
[Feature] 특정 기간 내 가게 별 리뷰 조회 API 구현

### DIFF
--- a/src/main/java/com/idukbaduk/itseats/review/controller/OwnerReviewController.java
+++ b/src/main/java/com/idukbaduk/itseats/review/controller/OwnerReviewController.java
@@ -1,11 +1,9 @@
 package com.idukbaduk.itseats.review.controller;
 
-import com.idukbaduk.itseats.auths.dto.CustomMemberDetails;
 import com.idukbaduk.itseats.global.response.BaseResponse;
 import com.idukbaduk.itseats.review.dto.ReviewListResponse;
 import com.idukbaduk.itseats.review.dto.enums.ReviewResponse;
 import com.idukbaduk.itseats.review.service.OwnerReviewService;
-import com.idukbaduk.itseats.review.service.ReviewService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
@@ -29,6 +27,9 @@ public class OwnerReviewController {
             @RequestParam("endDate") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime endDate,
             @AuthenticationPrincipal UserDetails userDetails
             ) {
+        if (startDate.isAfter(endDate)) {
+            throw new IllegalArgumentException("시작 날짜는 종료 날짜보다 이전이어야 합니다.");
+        }
         ReviewListResponse response =
                 ownerReviewService.getReviewsByStoreAndPeriod(storeId, startDate, endDate, userDetails.getUsername());
         return BaseResponse.toResponseEntity(ReviewResponse.GET_STORE_REVIEWS_BY_PERIOD, response);

--- a/src/main/java/com/idukbaduk/itseats/review/controller/OwnerReviewController.java
+++ b/src/main/java/com/idukbaduk/itseats/review/controller/OwnerReviewController.java
@@ -1,0 +1,36 @@
+package com.idukbaduk.itseats.review.controller;
+
+import com.idukbaduk.itseats.auths.dto.CustomMemberDetails;
+import com.idukbaduk.itseats.global.response.BaseResponse;
+import com.idukbaduk.itseats.review.dto.ReviewListResponse;
+import com.idukbaduk.itseats.review.dto.enums.ReviewResponse;
+import com.idukbaduk.itseats.review.service.OwnerReviewService;
+import com.idukbaduk.itseats.review.service.ReviewService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDateTime;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/owner")
+public class OwnerReviewController {
+
+    private final OwnerReviewService ownerReviewService;
+
+    @GetMapping("/{storeId}/reviews")
+    public ResponseEntity<BaseResponse> getStoreReviews(
+            @PathVariable("storeId") Long storeId,
+            @RequestParam("startDate") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime startDate,
+            @RequestParam("endDate") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime endDate,
+            @AuthenticationPrincipal UserDetails userDetails
+            ) {
+        ReviewListResponse response =
+                ownerReviewService.getReviewsByStoreAndPeriod(storeId, startDate, endDate, userDetails.getUsername());
+        return BaseResponse.toResponseEntity(ReviewResponse.GET_STORE_REVIEWS_BY_PERIOD, response);
+    }
+}

--- a/src/main/java/com/idukbaduk/itseats/review/controller/ReviewController.java
+++ b/src/main/java/com/idukbaduk/itseats/review/controller/ReviewController.java
@@ -2,6 +2,7 @@ package com.idukbaduk.itseats.review.controller;
 
 import com.idukbaduk.itseats.global.response.BaseResponse;
 import com.idukbaduk.itseats.review.dto.StoreReviewResponse;
+import com.idukbaduk.itseats.review.dto.enums.ReviewResponse;
 import com.idukbaduk.itseats.review.service.ReviewService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -21,6 +22,6 @@ public class ReviewController {
     @GetMapping("/{storeId}")
     public ResponseEntity<BaseResponse> getStoreReviews(@PathVariable Long storeId) {
         StoreReviewResponse response = reviewService.getReviewsByStore(storeId);
-        return BaseResponse.toResponseEntity(HttpStatus.OK, "가게 별 리뷰 목록 조회 성공", response);
+        return BaseResponse.toResponseEntity(ReviewResponse.GET_STORE_REVIEWS, response);
     }
 }

--- a/src/main/java/com/idukbaduk/itseats/review/dto/ReviewDto.java
+++ b/src/main/java/com/idukbaduk/itseats/review/dto/ReviewDto.java
@@ -1,0 +1,22 @@
+package com.idukbaduk.itseats.review.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ReviewDto {
+    private String reviewer;
+    private String menuName;
+    private String orderNumber;
+    private String reviewImageUrl;
+    private int rating;
+    private String content;
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/com/idukbaduk/itseats/review/dto/ReviewListResponse.java
+++ b/src/main/java/com/idukbaduk/itseats/review/dto/ReviewListResponse.java
@@ -1,0 +1,14 @@
+package com.idukbaduk.itseats.review.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class ReviewListResponse {
+    private String startDate;
+    private String endDate;
+    private List<ReviewDto> reviews;
+}

--- a/src/main/java/com/idukbaduk/itseats/review/dto/enums/ReviewResponse.java
+++ b/src/main/java/com/idukbaduk/itseats/review/dto/enums/ReviewResponse.java
@@ -1,0 +1,26 @@
+package com.idukbaduk.itseats.review.dto.enums;
+
+import com.idukbaduk.itseats.global.response.Response;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@RequiredArgsConstructor
+public enum ReviewResponse implements Response {
+
+    GET_STORE_REVIEWS(HttpStatus.OK, "가게 별 리뷰 조회 성공"),
+    GET_STORE_REVIEWS_BY_PERIOD(HttpStatus.OK, "특정 기간에 해당하는 리뷰 조회 성공"),
+    ;
+
+    private final HttpStatus httpStatus;
+    private final String message;
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return httpStatus;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+}

--- a/src/main/java/com/idukbaduk/itseats/review/repository/ReviewImageRepository.java
+++ b/src/main/java/com/idukbaduk/itseats/review/repository/ReviewImageRepository.java
@@ -7,5 +7,7 @@ import java.util.List;
 
 public interface ReviewImageRepository extends JpaRepository<ReviewImage, Long> {
     List<ReviewImage> findByReviewReviewIdInOrderByDisplayOrderAsc(List<Long> reviewIds);
+
+    List<ReviewImage> findByReview_ReviewIdIn(List<Long> reviewIds);
 }
 

--- a/src/main/java/com/idukbaduk/itseats/review/repository/ReviewRepository.java
+++ b/src/main/java/com/idukbaduk/itseats/review/repository/ReviewRepository.java
@@ -5,6 +5,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 public interface ReviewRepository extends JpaRepository<Review, Long> {
@@ -22,4 +23,7 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
 
     @Query("SELECT COUNT(r) FROM Review r WHERE r.store.storeId = :storeId")
     int countByStoreId(@Param("storeId") Long storeId);
+
+    List<Review> findByStore_StoreIdAndCreatedAtBetween(Long storeId, LocalDateTime start, LocalDateTime end);
+
 }

--- a/src/main/java/com/idukbaduk/itseats/review/service/OwnerReviewService.java
+++ b/src/main/java/com/idukbaduk/itseats/review/service/OwnerReviewService.java
@@ -1,0 +1,98 @@
+package com.idukbaduk.itseats.review.service;
+
+import com.idukbaduk.itseats.member.entity.Member;
+import com.idukbaduk.itseats.member.error.MemberException;
+import com.idukbaduk.itseats.member.error.enums.MemberErrorCode;
+import com.idukbaduk.itseats.member.repository.MemberRepository;
+import com.idukbaduk.itseats.order.entity.OrderMenu;
+import com.idukbaduk.itseats.review.dto.ReviewDto;
+import com.idukbaduk.itseats.review.dto.ReviewListResponse;
+import com.idukbaduk.itseats.review.entity.Review;
+import com.idukbaduk.itseats.review.entity.ReviewImage;
+import com.idukbaduk.itseats.review.repository.ReviewImageRepository;
+import com.idukbaduk.itseats.review.repository.ReviewRepository;
+import com.idukbaduk.itseats.store.entity.Store;
+import com.idukbaduk.itseats.store.error.StoreException;
+import com.idukbaduk.itseats.store.error.enums.StoreErrorCode;
+import com.idukbaduk.itseats.store.repository.StoreRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+
+@Service
+@RequiredArgsConstructor
+public class OwnerReviewService {
+
+    private final MemberRepository memberRepository;
+    private final StoreRepository storeRepository;
+    private final ReviewRepository reviewRepository;
+    private final ReviewImageRepository reviewImageRepository;
+
+    @Transactional(readOnly = true)
+    public ReviewListResponse getReviewsByStoreAndPeriod(
+            Long storeId, LocalDateTime startDate, LocalDateTime endDate, String username
+    ) {
+        Member member = memberRepository.findByUsername(username)
+                .orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
+        Store store = storeRepository.findById(storeId)
+                .orElseThrow(() -> new StoreException(StoreErrorCode.STORE_NOT_FOUND));
+        if (!store.getMember().getMemberId().equals(member.getMemberId())) {
+            throw new StoreException(StoreErrorCode.NOT_STORE_OWNER);
+        }
+        List<Review> reviews = fetchReviews(storeId, startDate, endDate);
+        List<Long> reviewIds = reviews.stream().map(Review::getReviewId).collect(Collectors.toList());
+        Map<Long, String> reviewIdToImageUrl = fetchReviewImages(reviewIds);
+        List<ReviewDto> reviewDtos = convertToDto(reviews, reviewIdToImageUrl);
+
+        return ReviewListResponse.builder()
+                .startDate(startDate.toString())
+                .endDate(endDate.toString())
+                .reviews(reviewDtos)
+                .build();
+    }
+
+    private List<Review> fetchReviews(Long storeId, LocalDateTime startDate, LocalDateTime endDate) {
+        return reviewRepository.findByStore_StoreIdAndCreatedAtBetween(storeId, startDate, endDate);
+    }
+
+    private Map<Long, String> fetchReviewImages(List<Long> reviewIds) {
+        List<ReviewImage> images = reviewImageRepository.findByReview_ReviewIdIn(reviewIds);
+        return images.stream()
+                .collect(Collectors.toMap(
+                        img -> img.getReview().getReviewId(),
+                        ReviewImage::getImageUrl
+                ));
+    }
+
+    private List<ReviewDto> convertToDto(List<Review> reviews, Map<Long, String> reviewIdToImageUrl) {
+        return reviews.stream()
+                .map(review -> {
+                    String menuName = null;
+                    String orderNumber = null;
+                    if (review.getOrder() != null) {
+                        List<OrderMenu> orderMenus = review.getOrder().getOrderMenus();
+                        if (orderMenus != null && !orderMenus.isEmpty()) {
+                            menuName = orderMenus.get(0).getMenuName();
+                        }
+                        orderNumber = review.getOrder().getOrderNumber();
+                    }
+                    String reviewer = review.getMember().getNickname();
+                    return ReviewDto.builder()
+                            .reviewer(reviewer)
+                            .menuName(menuName)
+                            .orderNumber(orderNumber)
+                            .reviewImageUrl(reviewIdToImageUrl.get(review.getReviewId()))
+                            .rating(review.getStoreStar())
+                            .content(review.getContent())
+                            .createdAt(review.getCreatedAt())
+                            .build();
+                })
+                .toList();
+    }
+}

--- a/src/main/java/com/idukbaduk/itseats/store/error/enums/StoreErrorCode.java
+++ b/src/main/java/com/idukbaduk/itseats/store/error/enums/StoreErrorCode.java
@@ -12,6 +12,7 @@ public enum StoreErrorCode implements ErrorCode {
     CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "카테고리 조회 실패"),
     FRANCHISE_NOT_FOUND(HttpStatus.NOT_FOUND, "프렌차이즈 조회 실패"),
     FRANCHISE_ID_REQUIRED(HttpStatus.BAD_REQUEST, "프랜차이즈 매장일 경우 franchiseId가 필요합니다."),
+    NOT_STORE_OWNER(HttpStatus.FORBIDDEN, "해당 가맹점의 소유자가 아닙니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/test/java/com/idukbaduk/itseats/review/controller/OwnerReviewControllerTest.java
+++ b/src/test/java/com/idukbaduk/itseats/review/controller/OwnerReviewControllerTest.java
@@ -16,6 +16,7 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 
 import static org.mockito.ArgumentMatchers.any;
@@ -117,8 +118,8 @@ class OwnerReviewControllerTest {
 
         // when & then
         mockMvc.perform(get("/api/owner/{storeId}/reviews", storeId)
-                        .param("startDate", startDate.toString())
-                        .param("endDate", endDate.toString()))
+                        .param("startDate", startDate.format(DateTimeFormatter.ISO_DATE_TIME))
+                        .param("endDate", endDate.format(DateTimeFormatter.ISO_DATE_TIME)))
                 .andExpect(status().isNotFound());
     }
 }

--- a/src/test/java/com/idukbaduk/itseats/review/controller/OwnerReviewControllerTest.java
+++ b/src/test/java/com/idukbaduk/itseats/review/controller/OwnerReviewControllerTest.java
@@ -1,0 +1,124 @@
+package com.idukbaduk.itseats.review.controller;
+
+import com.idukbaduk.itseats.review.dto.ReviewDto;
+import com.idukbaduk.itseats.review.dto.ReviewListResponse;
+import com.idukbaduk.itseats.review.dto.enums.ReviewResponse;
+import com.idukbaduk.itseats.review.service.OwnerReviewService;
+import com.idukbaduk.itseats.store.error.StoreException;
+import com.idukbaduk.itseats.store.error.enums.StoreErrorCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(OwnerReviewController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class OwnerReviewControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private OwnerReviewService ownerReviewService;
+
+    @Test
+    @DisplayName("가게 리뷰 조회 성공")
+    @WithMockUser(username = "testowner")
+    void getStoreReviews_success() throws Exception {
+        // given
+        Long storeId = 1L;
+        LocalDateTime startDate = LocalDateTime.of(2024, 1, 1, 0, 0);
+        LocalDateTime endDate = LocalDateTime.of(2024, 1, 31, 23, 59);
+        String username = "testowner";
+
+        ReviewDto reviewDto = ReviewDto.builder()
+                .reviewer("테스트리뷰어")
+                .menuName("테스트메뉴")
+                .orderNumber("ORDER123")
+                .reviewImageUrl("http://test.com/image.jpg")
+                .rating(5)
+                .content("맛있어요!")
+                .createdAt(LocalDateTime.now())
+                .build();
+
+        ReviewListResponse response = ReviewListResponse.builder()
+                .startDate(startDate.toString())
+                .endDate(endDate.toString())
+                .reviews(List.of(reviewDto))
+                .build();
+
+        when(ownerReviewService.getReviewsByStoreAndPeriod(
+                any(Long.class),
+                any(LocalDateTime.class),
+                any(LocalDateTime.class),
+                any(String.class)))
+                .thenReturn(response);
+
+        // when & then
+        mockMvc.perform(get("/api/owner/{storeId}/reviews", storeId)
+                        .param("startDate", startDate.toString())
+                        .param("endDate", endDate.toString()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value(ReviewResponse.GET_STORE_REVIEWS_BY_PERIOD.getMessage()))
+                .andExpect(jsonPath("$.data.reviews[0].reviewer").value("테스트리뷰어"));
+    }
+
+    @Test
+    @DisplayName("가게 리뷰 조회 실패 - 가게 소유자가 아님")
+    @WithMockUser(username = "testuser")
+    void getStoreReviews_notStoreOwner() throws Exception {
+        // given
+        Long storeId = 1L;
+        LocalDateTime startDate = LocalDateTime.of(2024, 1, 1, 0, 0);
+        LocalDateTime endDate = LocalDateTime.of(2024, 1, 31, 23, 59);
+
+        when(ownerReviewService.getReviewsByStoreAndPeriod(
+                any(Long.class),
+                any(LocalDateTime.class),
+                any(LocalDateTime.class),
+                any(String.class)))
+                .thenThrow(new StoreException(StoreErrorCode.NOT_STORE_OWNER));
+
+        // when & then
+        mockMvc.perform(get("/api/owner/{storeId}/reviews", storeId)
+                        .param("startDate", startDate.toString())
+                        .param("endDate", endDate.toString()))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @DisplayName("가게 리뷰 조회 실패 - 존재하지 않는 가게")
+    @WithMockUser(username = "testowner")
+    void getStoreReviews_storeNotFound() throws Exception {
+        // given
+        Long storeId = 999L;
+        LocalDateTime startDate = LocalDateTime.of(2024, 1, 1, 0, 0);
+        LocalDateTime endDate = LocalDateTime.of(2024, 1, 31, 23, 59);
+
+        when(ownerReviewService.getReviewsByStoreAndPeriod(
+                any(Long.class),
+                any(LocalDateTime.class),
+                any(LocalDateTime.class),
+                any(String.class)))
+                .thenThrow(new StoreException(StoreErrorCode.STORE_NOT_FOUND));
+
+        // when & then
+        mockMvc.perform(get("/api/owner/{storeId}/reviews", storeId)
+                        .param("startDate", startDate.toString())
+                        .param("endDate", endDate.toString()))
+                .andExpect(status().isNotFound());
+    }
+}

--- a/src/test/java/com/idukbaduk/itseats/review/service/OwnerReviewServiceTest.java
+++ b/src/test/java/com/idukbaduk/itseats/review/service/OwnerReviewServiceTest.java
@@ -1,6 +1,7 @@
 package com.idukbaduk.itseats.review.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
 
 import com.idukbaduk.itseats.member.entity.Member;
@@ -14,6 +15,8 @@ import com.idukbaduk.itseats.review.entity.ReviewImage;
 import com.idukbaduk.itseats.review.repository.ReviewImageRepository;
 import com.idukbaduk.itseats.review.repository.ReviewRepository;
 import com.idukbaduk.itseats.store.entity.Store;
+import com.idukbaduk.itseats.store.error.StoreException;
+import com.idukbaduk.itseats.store.error.enums.StoreErrorCode;
 import com.idukbaduk.itseats.store.repository.StoreRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -96,5 +99,68 @@ class OwnerReviewServiceTest {
         assertThat(dto.getRating()).isEqualTo(5);
         assertThat(dto.getContent()).isEqualTo("맛있어요");
         assertThat(dto.getReviewer()).isEqualTo(username);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 가게의 리뷰 조회 시 예외 발생")
+    void getReviewsByStoreAndPeriod_storeNotFound() {
+        // given
+        Long nonExistentStoreId = 999L;
+        String username = "user1";
+        LocalDateTime startDate = LocalDateTime.now().minusDays(30);
+        LocalDateTime endDate = LocalDateTime.now();
+
+        Member member = Member.builder()
+                .memberId(10L)
+                .username(username)
+                .nickname("user1")
+                .build();
+
+        given(memberRepository.findByUsername(username)).willReturn(Optional.of(member));
+        given(storeRepository.findById(nonExistentStoreId)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() ->
+                ownerReviewService.getReviewsByStoreAndPeriod(nonExistentStoreId, startDate, endDate, username)
+        )
+                .isInstanceOf(StoreException.class)
+                .hasFieldOrPropertyWithValue("errorCode", StoreErrorCode.STORE_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("가게 주인이 아닌 경우 리뷰 조회 시 예외 발생")
+    void getReviewsByStoreAndPeriod_notStoreOwner() {
+        // given
+        Long storeId = 1L;
+        String username = "user1";
+        LocalDateTime startDate = LocalDateTime.now().minusDays(30);
+        LocalDateTime endDate = LocalDateTime.now();
+
+        Member requestMember = Member.builder()
+                .memberId(10L)
+                .username(username)
+                .nickname("user1")
+                .build();
+
+        Member storeOwner = Member.builder()
+                .memberId(20L)
+                .username("owner")
+                .nickname("owner")
+                .build();
+
+        Store store = Store.builder()
+                .storeId(storeId)
+                .member(storeOwner)  // 다른 사용자가 가게 주인
+                .build();
+
+        given(memberRepository.findByUsername(username)).willReturn(Optional.of(requestMember));
+        given(storeRepository.findById(storeId)).willReturn(Optional.of(store));
+
+        // when & then
+        assertThatThrownBy(() ->
+                ownerReviewService.getReviewsByStoreAndPeriod(storeId, startDate, endDate, username)
+        )
+                .isInstanceOf(StoreException.class)
+                .hasFieldOrPropertyWithValue("errorCode", StoreErrorCode.NOT_STORE_OWNER);
     }
 }

--- a/src/test/java/com/idukbaduk/itseats/review/service/OwnerReviewServiceTest.java
+++ b/src/test/java/com/idukbaduk/itseats/review/service/OwnerReviewServiceTest.java
@@ -1,0 +1,100 @@
+package com.idukbaduk.itseats.review.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+import com.idukbaduk.itseats.member.entity.Member;
+import com.idukbaduk.itseats.member.repository.MemberRepository;
+import com.idukbaduk.itseats.order.entity.Order;
+import com.idukbaduk.itseats.review.dto.ReviewDto;
+import com.idukbaduk.itseats.review.dto.ReviewListResponse;
+import com.idukbaduk.itseats.order.entity.OrderMenu;
+import com.idukbaduk.itseats.review.entity.Review;
+import com.idukbaduk.itseats.review.entity.ReviewImage;
+import com.idukbaduk.itseats.review.repository.ReviewImageRepository;
+import com.idukbaduk.itseats.review.repository.ReviewRepository;
+import com.idukbaduk.itseats.store.entity.Store;
+import com.idukbaduk.itseats.store.repository.StoreRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.lang.reflect.Field;
+import java.time.LocalDateTime;
+import java.util.*;
+
+@ExtendWith(MockitoExtension.class)
+class OwnerReviewServiceTest {
+
+    @Mock
+    private ReviewRepository reviewRepository;
+    @Mock
+    private ReviewImageRepository reviewImageRepository;
+    @Mock
+    private StoreRepository storeRepository;
+    @Mock
+    private MemberRepository memberRepository;
+
+    @InjectMocks
+    private OwnerReviewService ownerReviewService;
+
+    @Test
+    @DisplayName("특정 기간 내 가게 별 리뷰 조회 성공")
+    void getReviewsByStoreAndPeriod_success() throws NoSuchFieldException, IllegalAccessException {
+        // given
+        Long storeId = 1L;
+        String username = "user1";
+        LocalDateTime startDate = LocalDateTime.now().minusDays(30);
+        LocalDateTime endDate = LocalDateTime.now();
+
+        Member member = Member.builder().memberId(10L).username(username).nickname("user1").build();
+        Store store = Store.builder().storeId(storeId).member(member).build();
+
+        Review review = Review.builder()
+                .reviewId(100L)
+                .storeStar(5)
+                .content("맛있어요")
+                .member(member)
+                .order(Order.builder()
+                        .orderNumber("ORD123")
+                        .orderMenus(List.of(
+                                OrderMenu.builder().menuName("아이스 아메리카노")
+                                        .build()))
+                        .build())
+                .build();
+
+        Field createdAtField = review.getClass().getSuperclass().getDeclaredField("createdAt");
+        createdAtField.setAccessible(true);
+        createdAtField.set(review, endDate);
+
+        ReviewImage reviewImage = ReviewImage.builder()
+                .reviewImageId(200L)
+                .review(review)
+                .imageUrl("http://image.url/1.jpg")
+                .build();
+
+        given(memberRepository.findByUsername(username)).willReturn(Optional.of(member));
+        given(storeRepository.findById(storeId)).willReturn(Optional.of(store));
+        given(reviewRepository.findByStore_StoreIdAndCreatedAtBetween(storeId, startDate, endDate))
+                .willReturn(List.of(review));
+        given(reviewImageRepository.findByReview_ReviewIdIn(List.of(100L)))
+                .willReturn(List.of(reviewImage));
+
+        // when
+        ReviewListResponse response = ownerReviewService.getReviewsByStoreAndPeriod(storeId, startDate, endDate, username);
+
+        // then
+        assertThat(response.getReviews()).hasSize(1);
+        ReviewDto dto = response.getReviews().get(0);
+        assertThat(dto.getMenuName()).isEqualTo("아이스 아메리카노");
+        assertThat(dto.getOrderNumber()).isEqualTo("ORD123");
+        assertThat(dto.getReviewImageUrl()).isEqualTo("http://image.url/1.jpg");
+        assertThat(dto.getRating()).isEqualTo(5);
+        assertThat(dto.getContent()).isEqualTo("맛있어요");
+        assertThat(dto.getReviewer()).isEqualTo(username);
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

#180 

## 📝작업 내용

- [ ] Dto - `ReviewDto`, `ReviewListResponse` 작성
- [ ] `OwnerReviewService`, `OwnerReviewController` 추가
- [ ] 테스트 코드 작성 후 작동 확인 완료

### 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/aa3ad48c-cf3b-41d2-b1f6-60b21b11a6fe)
![image](https://github.com/user-attachments/assets/9fdb4732-6b68-4925-a27d-523bd0cd64b9)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 점주가 특정 기간 동안 자신의 매장에 작성된 리뷰를 조회할 수 있는 API가 추가되었습니다.

* **버그 수정**
  * 리뷰 조회 시 응답 메시지 및 상태 코드가 표준화되었습니다.

* **테스트**
  * 점주 리뷰 조회 API 및 서비스에 대한 단위 테스트와 컨트롤러 테스트가 추가되었습니다.

* **기타**
  * 리뷰 관련 데이터 전달 객체(DTO), 응답 메시지, 에러 코드가 확장되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->