### PR TITLE
[Feature] 내 정보 조회 API 구현

### DIFF
--- a/src/main/java/com/idukbaduk/itseats/global/config/CorsConfig.java
+++ b/src/main/java/com/idukbaduk/itseats/global/config/CorsConfig.java
@@ -21,7 +21,7 @@ public class CorsConfig {
         config.setAllowedHeaders(List.of("*"));
         config.setAllowCredentials(true);
 
-        config.setExposedHeaders(List.of("access-token"));
+        config.setExposedHeaders(List.of("access-token", "Access-Token"));
 
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
         source.registerCorsConfiguration("/**", config);

--- a/src/main/java/com/idukbaduk/itseats/global/config/CorsConfig.java
+++ b/src/main/java/com/idukbaduk/itseats/global/config/CorsConfig.java
@@ -21,6 +21,8 @@ public class CorsConfig {
         config.setAllowedHeaders(List.of("*"));
         config.setAllowCredentials(true);
 
+        config.setExposedHeaders(List.of("access-token"));
+
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
         source.registerCorsConfiguration("/**", config);
         return source;

--- a/src/main/java/com/idukbaduk/itseats/member/controller/MemberController.java
+++ b/src/main/java/com/idukbaduk/itseats/member/controller/MemberController.java
@@ -8,10 +8,9 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.*;
 
 @Slf4j
 @RestController
@@ -29,4 +28,11 @@ public class MemberController {
         );
     }
 
+    @GetMapping("/me")
+    public ResponseEntity<BaseResponse> getCurrentMember(@AuthenticationPrincipal UserDetails userDetails) {
+        return BaseResponse.toResponseEntity(
+                MemberResponse.GET_CURRENT_MEMBER_SUCCESS,
+                memberService.getCurrentMember(userDetails.getUsername())
+        );
+    }
 }

--- a/src/main/java/com/idukbaduk/itseats/member/dto/enums/MemberResponse.java
+++ b/src/main/java/com/idukbaduk/itseats/member/dto/enums/MemberResponse.java
@@ -7,7 +7,8 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum MemberResponse implements Response {
 
-    CREATE_MEMBER_SUCCESS(HttpStatus.CREATED, "회원 가입 성공");
+    CREATE_MEMBER_SUCCESS(HttpStatus.CREATED, "회원 가입 성공"),
+    GET_CURRENT_MEMBER_SUCCESS(HttpStatus.OK, "내 정보 조회 성공");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/idukbaduk/itseats/member/dto/response/CurrentMemberResponse.java
+++ b/src/main/java/com/idukbaduk/itseats/member/dto/response/CurrentMemberResponse.java
@@ -1,0 +1,33 @@
+package com.idukbaduk.itseats.member.dto.response;
+
+import com.idukbaduk.itseats.member.entity.Member;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class CurrentMemberResponse {
+    private Long memberId;
+    private String username;
+    private String name;
+    private String nickname;
+    private String email;
+    private String phone;
+    private String memberType;
+    private Integer reviewCount;
+    private Integer favoriteCount;
+
+    public static CurrentMemberResponse of(Member member, int reviewCount, int favoriteCount) {
+        return CurrentMemberResponse.builder()
+                .memberId(member.getMemberId())
+                .username(member.getUsername())
+                .name(member.getName())
+                .nickname(member.getNickname())
+                .email(member.getEmail())
+                .phone(member.getPhone())
+                .memberType(member.getMemberType().name())
+                .reviewCount(reviewCount)
+                .favoriteCount(favoriteCount)
+                .build();
+    }
+}

--- a/src/main/java/com/idukbaduk/itseats/member/repository/FavoriteRepository.java
+++ b/src/main/java/com/idukbaduk/itseats/member/repository/FavoriteRepository.java
@@ -7,4 +7,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface FavoriteRepository extends JpaRepository<Favorite, Long> {
     boolean existsByMemberAndStore(Member member, Store store);
+
+    int countByMember(Member member);
 }

--- a/src/main/java/com/idukbaduk/itseats/member/service/MemberService.java
+++ b/src/main/java/com/idukbaduk/itseats/member/service/MemberService.java
@@ -1,11 +1,14 @@
 package com.idukbaduk.itseats.member.service;
 
 import com.idukbaduk.itseats.member.dto.CustomerDto;
+import com.idukbaduk.itseats.member.dto.response.CurrentMemberResponse;
 import com.idukbaduk.itseats.member.dto.response.CustomerCreateResponse;
 import com.idukbaduk.itseats.member.entity.Member;
 import com.idukbaduk.itseats.member.error.MemberException;
 import com.idukbaduk.itseats.member.error.enums.MemberErrorCode;
+import com.idukbaduk.itseats.member.repository.FavoriteRepository;
 import com.idukbaduk.itseats.member.repository.MemberRepository;
+import com.idukbaduk.itseats.review.repository.ReviewRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -17,6 +20,8 @@ public class MemberService {
 
     private final PasswordEncoder passwordEncoder;
     private final MemberRepository memberRepository;
+    private final ReviewRepository reviewRepository;
+    private final FavoriteRepository favoriteRepository;
 
     public Member getMemberByUsername(String username) {
         return memberRepository.findByUsername(username)
@@ -43,4 +48,14 @@ public class MemberService {
         return CustomerCreateResponse.of(newCustomer.getMemberId());
     }
 
+    public CurrentMemberResponse getCurrentMember(String username) {
+        Member member = memberRepository.findByUsername(username).orElseThrow(
+                () -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND)
+        );
+
+        int reviewCount = reviewRepository.countByMember(member);
+        int favoriteCount = favoriteRepository.countByMember(member);
+
+        return CurrentMemberResponse.of(member, reviewCount, favoriteCount);
+    }
 }

--- a/src/main/java/com/idukbaduk/itseats/review/repository/ReviewRepository.java
+++ b/src/main/java/com/idukbaduk/itseats/review/repository/ReviewRepository.java
@@ -1,5 +1,6 @@
 package com.idukbaduk.itseats.review.repository;
 
+import com.idukbaduk.itseats.member.entity.Member;
 import com.idukbaduk.itseats.review.entity.Review;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -22,4 +23,6 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
 
     @Query("SELECT COUNT(r) FROM Review r WHERE r.store.storeId = :storeId")
     int countByStoreId(@Param("storeId") Long storeId);
+
+    int countByMember(Member member);
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

#184
closes #184

## 📝작업 내용

현재 로그인된 회원의 정보를 조회하는 API를 구현합니다.

- [x] 내 정보 조회 service 로직 구현
- [x] controller 로직 구현
- [x] 테스트 코드 작성

### 스크린샷 (선택)

![image](https://github.com/user-attachments/assets/6814c8aa-f029-4383-8a37-a5e261c8fc4a)

## 💬리뷰 요구사항(선택)

요청으로 들어온 token을 검증하고, userDetails 객체를 넣어주는 필터가 아직 없어 임시로 만들어 테스트했습니다. 만든 필터 코드는 `feat/temporal-token-filter` 브랜치로 커밋하겠습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 현재 로그인한 사용자의 정보를 조회하는 새로운 API 엔드포인트(`/me`)가 추가되었습니다. 해당 엔드포인트를 통해 회원 정보, 리뷰 수, 즐겨찾기 수를 확인할 수 있습니다.

* **버그 수정**
  * CORS 설정에서 "access-token" 및 "Access-Token" 헤더가 노출되도록 개선되었습니다.

* **테스트**
  * 현재 회원 정보 조회 기능에 대한 단위 테스트가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->