### PR TITLE
[Feature] 악성 리뷰 신고 API 구현

### DIFF
--- a/src/main/java/com/idukbaduk/itseats/review/controller/OwnerReviewController.java
+++ b/src/main/java/com/idukbaduk/itseats/review/controller/OwnerReviewController.java
@@ -1,0 +1,33 @@
+package com.idukbaduk.itseats.review.controller;
+
+import com.idukbaduk.itseats.global.response.BaseResponse;
+import com.idukbaduk.itseats.review.dto.ReviewReportRequest;
+import com.idukbaduk.itseats.review.dto.ReviewReportResponse;
+import com.idukbaduk.itseats.review.dto.enums.ReviewResponse;
+import com.idukbaduk.itseats.review.service.OwnerReviewService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/owner")
+public class OwnerReviewController {
+
+    private final OwnerReviewService ownerReviewService;
+
+    @PostMapping("/{storeId}/reviews/{reviewId}/report")
+    public ResponseEntity<BaseResponse> reportReview(
+            @PathVariable("storeId") Long storeId,
+            @PathVariable("reviewId") Long reviewId,
+            @RequestBody ReviewReportRequest request,
+            @AuthenticationPrincipal UserDetails userDetails
+    ) {
+        ReviewReportResponse response =
+                ownerReviewService.reportReview(userDetails.getUsername(), storeId, reviewId, request);
+
+        return BaseResponse.toResponseEntity(ReviewResponse.REPORT_REVIEW_SUCCESS, response);
+    }
+}

--- a/src/main/java/com/idukbaduk/itseats/review/controller/OwnerReviewController.java
+++ b/src/main/java/com/idukbaduk/itseats/review/controller/OwnerReviewController.java
@@ -5,6 +5,7 @@ import com.idukbaduk.itseats.review.dto.ReviewReportRequest;
 import com.idukbaduk.itseats.review.dto.ReviewReportResponse;
 import com.idukbaduk.itseats.review.dto.enums.ReviewResponse;
 import com.idukbaduk.itseats.review.service.OwnerReviewService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -22,7 +23,7 @@ public class OwnerReviewController {
     public ResponseEntity<BaseResponse> reportReview(
             @PathVariable("storeId") Long storeId,
             @PathVariable("reviewId") Long reviewId,
-            @RequestBody ReviewReportRequest request,
+            @RequestBody @Valid ReviewReportRequest request,
             @AuthenticationPrincipal UserDetails userDetails
     ) {
         ReviewReportResponse response =

--- a/src/main/java/com/idukbaduk/itseats/review/dto/ReviewReportRequest.java
+++ b/src/main/java/com/idukbaduk/itseats/review/dto/ReviewReportRequest.java
@@ -1,0 +1,14 @@
+package com.idukbaduk.itseats.review.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ReviewReportRequest {
+    private String reason;
+}

--- a/src/main/java/com/idukbaduk/itseats/review/dto/ReviewReportRequest.java
+++ b/src/main/java/com/idukbaduk/itseats/review/dto/ReviewReportRequest.java
@@ -1,5 +1,6 @@
 package com.idukbaduk.itseats.review.dto;
 
+import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -10,5 +11,6 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class ReviewReportRequest {
+    @NotBlank(message = "신고 사유는 필수입니다.")
     private String reason;
 }

--- a/src/main/java/com/idukbaduk/itseats/review/dto/ReviewReportResponse.java
+++ b/src/main/java/com/idukbaduk/itseats/review/dto/ReviewReportResponse.java
@@ -1,0 +1,17 @@
+package com.idukbaduk.itseats.review.dto;
+
+import com.idukbaduk.itseats.review.entity.enums.ReportStatus;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class ReviewReportResponse {
+    private String reporter;
+    private Long reviewId;
+    private String reason;
+    private LocalDateTime reportedAt;
+    private ReportStatus reportStatus;
+}

--- a/src/main/java/com/idukbaduk/itseats/review/dto/enums/ReviewResponse.java
+++ b/src/main/java/com/idukbaduk/itseats/review/dto/enums/ReviewResponse.java
@@ -1,0 +1,25 @@
+package com.idukbaduk.itseats.review.dto.enums;
+
+import com.idukbaduk.itseats.global.response.Response;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@RequiredArgsConstructor
+public enum ReviewResponse implements Response {
+
+    REPORT_REVIEW_SUCCESS(HttpStatus.CREATED, "리뷰가 신고되었습니다.")
+    ;
+
+    private final HttpStatus httpStatus;
+    private final String message;
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return httpStatus;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+}

--- a/src/main/java/com/idukbaduk/itseats/review/entity/ReviewReport.java
+++ b/src/main/java/com/idukbaduk/itseats/review/entity/ReviewReport.java
@@ -1,0 +1,48 @@
+package com.idukbaduk.itseats.review.entity;
+
+import com.idukbaduk.itseats.global.BaseEntity;
+import com.idukbaduk.itseats.member.entity.Member;
+import com.idukbaduk.itseats.review.entity.enums.ReportStatus;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(name = "review_report")
+public class ReviewReport extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "report_id")
+    private Long reportId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "review_id", nullable = false)
+    private Review review;
+
+    @Column(name = "reason", nullable = false)
+    private String reason;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "report_status", nullable = false)
+    private ReportStatus reportStatus;
+
+    public static ReviewReport create(Member member, Review review, String reason) {
+        return ReviewReport.builder()
+                .member(member)
+                .review(review)
+                .reason(reason)
+                .reportStatus(ReportStatus.ACCEPTED)
+                .build();
+    }
+}

--- a/src/main/java/com/idukbaduk/itseats/review/entity/enums/ReportStatus.java
+++ b/src/main/java/com/idukbaduk/itseats/review/entity/enums/ReportStatus.java
@@ -1,0 +1,7 @@
+package com.idukbaduk.itseats.review.entity.enums;
+
+public enum ReportStatus {
+    PENDING,
+    ACCEPTED,
+    REJECTED
+}

--- a/src/main/java/com/idukbaduk/itseats/review/error/ReviewErrorCode.java
+++ b/src/main/java/com/idukbaduk/itseats/review/error/ReviewErrorCode.java
@@ -9,6 +9,7 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum ReviewErrorCode implements ErrorCode {
     REVIEW_NOT_FOUND(HttpStatus.NOT_FOUND, "리뷰가 없습니다."),
+    ALREADY_REPORTED(HttpStatus.CONFLICT, "이미 신고한 리뷰입니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/idukbaduk/itseats/review/repository/ReviewReportRepository.java
+++ b/src/main/java/com/idukbaduk/itseats/review/repository/ReviewReportRepository.java
@@ -1,0 +1,8 @@
+package com.idukbaduk.itseats.review.repository;
+
+import com.idukbaduk.itseats.review.entity.ReviewReport;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ReviewReportRepository extends JpaRepository<ReviewReport, Long> {
+    boolean existsByMember_MemberIdAndReview_ReviewId(Long memberId, Long reviewId);
+}

--- a/src/main/java/com/idukbaduk/itseats/review/service/OwnerReviewService.java
+++ b/src/main/java/com/idukbaduk/itseats/review/service/OwnerReviewService.java
@@ -1,0 +1,62 @@
+package com.idukbaduk.itseats.review.service;
+
+import com.idukbaduk.itseats.member.entity.Member;
+import com.idukbaduk.itseats.member.error.MemberException;
+import com.idukbaduk.itseats.member.error.enums.MemberErrorCode;
+import com.idukbaduk.itseats.member.repository.MemberRepository;
+import com.idukbaduk.itseats.review.dto.ReviewReportRequest;
+import com.idukbaduk.itseats.review.dto.ReviewReportResponse;
+import com.idukbaduk.itseats.review.entity.Review;
+import com.idukbaduk.itseats.review.entity.ReviewReport;
+import com.idukbaduk.itseats.review.error.ReviewErrorCode;
+import com.idukbaduk.itseats.review.error.ReviewException;
+import com.idukbaduk.itseats.review.repository.ReviewReportRepository;
+import com.idukbaduk.itseats.review.repository.ReviewRepository;
+import com.idukbaduk.itseats.store.entity.Store;
+import com.idukbaduk.itseats.store.error.StoreException;
+import com.idukbaduk.itseats.store.error.enums.StoreErrorCode;
+import com.idukbaduk.itseats.store.repository.StoreRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class OwnerReviewService {
+
+    private final ReviewReportRepository reviewReportRepository;
+    private final MemberRepository memberRepository;
+    private final ReviewRepository reviewRepository;
+    private final StoreRepository storeRepository;
+
+    public ReviewReportResponse reportReview(
+            String username, Long storeId, Long reviewId, ReviewReportRequest request
+    ) {
+        Member member = memberRepository.findByUsername(username)
+                .orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
+
+        Store store = storeRepository.findById(storeId)
+                .orElseThrow(() -> new StoreException(StoreErrorCode.STORE_NOT_FOUND));
+        if (!store.getMember().getMemberId().equals(member.getMemberId())) {
+            throw new StoreException(StoreErrorCode.NOT_STORE_OWNER);
+        }
+
+        Review review = reviewRepository.findById(reviewId)
+                .orElseThrow(() -> new ReviewException(ReviewErrorCode.REVIEW_NOT_FOUND));
+
+        if (reviewReportRepository.existsByMember_MemberIdAndReview_ReviewId(member.getMemberId(), review.getReviewId())) {
+            throw new ReviewException(ReviewErrorCode.ALREADY_REPORTED);
+        }
+
+        ReviewReport report = ReviewReport.create(member, review, request.getReason());
+
+        reviewReportRepository.save(report);
+
+        return ReviewReportResponse.builder()
+                .reporter(member.getUsername())
+                .reviewId(review.getReviewId())
+                .reason(report.getReason())
+                .reportedAt(report.getCreatedAt())
+                .reportStatus(report.getReportStatus())
+                .build();
+    }
+}

--- a/src/main/java/com/idukbaduk/itseats/review/service/OwnerReviewService.java
+++ b/src/main/java/com/idukbaduk/itseats/review/service/OwnerReviewService.java
@@ -18,6 +18,7 @@ import com.idukbaduk.itseats.store.error.enums.StoreErrorCode;
 import com.idukbaduk.itseats.store.repository.StoreRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -28,6 +29,7 @@ public class OwnerReviewService {
     private final ReviewRepository reviewRepository;
     private final StoreRepository storeRepository;
 
+    @Transactional
     public ReviewReportResponse reportReview(
             String username, Long storeId, Long reviewId, ReviewReportRequest request
     ) {

--- a/src/main/java/com/idukbaduk/itseats/store/error/enums/StoreErrorCode.java
+++ b/src/main/java/com/idukbaduk/itseats/store/error/enums/StoreErrorCode.java
@@ -12,6 +12,7 @@ public enum StoreErrorCode implements ErrorCode {
     CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "카테고리 조회 실패"),
     FRANCHISE_NOT_FOUND(HttpStatus.NOT_FOUND, "프렌차이즈 조회 실패"),
     FRANCHISE_ID_REQUIRED(HttpStatus.BAD_REQUEST, "프랜차이즈 매장일 경우 franchiseId가 필요합니다."),
+    NOT_STORE_OWNER(HttpStatus.FORBIDDEN, "해당 가맹점의 소유자가 아닙니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/test/java/com/idukbaduk/itseats/review/controller/ReviewReportControllerTest.java
+++ b/src/test/java/com/idukbaduk/itseats/review/controller/ReviewReportControllerTest.java
@@ -1,0 +1,143 @@
+package com.idukbaduk.itseats.review.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.idukbaduk.itseats.global.response.BaseResponse;
+import com.idukbaduk.itseats.review.dto.ReviewReportRequest;
+import com.idukbaduk.itseats.review.dto.ReviewReportResponse;
+import com.idukbaduk.itseats.review.dto.enums.ReviewResponse;
+import com.idukbaduk.itseats.review.entity.enums.ReportStatus;
+import com.idukbaduk.itseats.review.error.ReviewErrorCode;
+import com.idukbaduk.itseats.review.error.ReviewException;
+import com.idukbaduk.itseats.review.service.OwnerReviewService;
+import com.idukbaduk.itseats.store.error.StoreException;
+import com.idukbaduk.itseats.store.error.enums.StoreErrorCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDateTime;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doThrow;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(OwnerReviewController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class ReviewReportControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private OwnerReviewService ownerReviewService;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    @DisplayName("리뷰 신고 성공")
+    @WithMockUser(username = "owner1")
+    void reportReview_success() throws Exception {
+        // given
+        Long storeId = 10L;
+        Long reviewId = 100L;
+        String reason = "욕설";
+        ReviewReportRequest request = ReviewReportRequest.builder()
+                .reason(reason)
+                .build();
+
+        ReviewReportResponse response = ReviewReportResponse.builder()
+                .reporter("owner1")
+                .reviewId(reviewId)
+                .reason(reason)
+                .reportedAt(LocalDateTime.of(2025, 7, 7, 15, 30))
+                .reportStatus(ReportStatus.ACCEPTED)
+                .build();
+
+        given(ownerReviewService.reportReview(eq("owner1"), eq(storeId), eq(reviewId), any(ReviewReportRequest.class)))
+                .willReturn(response);
+
+        // when & then
+        mockMvc.perform(post("/api/owner/{storeId}/reviews/{reviewId}/report", storeId, reviewId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.httpStatus").value(ReviewResponse.REPORT_REVIEW_SUCCESS.getHttpStatus().value()))
+                .andExpect(jsonPath("$.message").value(ReviewResponse.REPORT_REVIEW_SUCCESS.getMessage()))
+                .andExpect(jsonPath("$.data.reporter").value("owner1"))
+                .andExpect(jsonPath("$.data.reviewId").value(reviewId))
+                .andExpect(jsonPath("$.data.reason").value(reason))
+                .andExpect(jsonPath("$.data.reportStatus").value("ACCEPTED"));
+    }
+
+    @Test
+    @DisplayName("가맹점주가 아니면 403 반환")
+    @WithMockUser(username = "owner1")
+    void reportReview_notStoreOwner() throws Exception {
+        // given
+        Long storeId = 10L;
+        Long reviewId = 100L;
+        ReviewReportRequest request = ReviewReportRequest.builder()
+                .reason("욕설")
+                .build();
+
+        doThrow(new StoreException(StoreErrorCode.NOT_STORE_OWNER))
+                .when(ownerReviewService).reportReview(eq("owner1"), eq(storeId), eq(reviewId), any(ReviewReportRequest.class));
+
+        // when & then
+        mockMvc.perform(post("/api/owner/{storeId}/reviews/{reviewId}/report", storeId, reviewId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @DisplayName("리뷰가 없으면 404 반환")
+    @WithMockUser(username = "owner1")
+    void reportReview_reviewNotFound() throws Exception {
+        // given
+        Long storeId = 10L;
+        Long reviewId = 100L;
+        ReviewReportRequest request = ReviewReportRequest.builder()
+                .reason("욕설")
+                .build();
+
+        doThrow(new ReviewException(ReviewErrorCode.REVIEW_NOT_FOUND))
+                .when(ownerReviewService).reportReview(eq("owner1"), eq(storeId), eq(reviewId), any(ReviewReportRequest.class));
+
+        // when & then
+        mockMvc.perform(post("/api/owner/{storeId}/reviews/{reviewId}/report", storeId, reviewId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    @DisplayName("중복 신고 시 409 반환")
+    @WithMockUser(username = "owner1")
+    void reportReview_alreadyReported() throws Exception {
+        // given
+        Long storeId = 10L;
+        Long reviewId = 100L;
+        ReviewReportRequest request = ReviewReportRequest.builder()
+                .reason("욕설")
+                .build();
+
+        doThrow(new ReviewException(ReviewErrorCode.ALREADY_REPORTED))
+                .when(ownerReviewService).reportReview(eq("owner1"), eq(storeId), eq(reviewId), any(ReviewReportRequest.class));
+
+        // when & then
+        mockMvc.perform(post("/api/owner/{storeId}/reviews/{reviewId}/report", storeId, reviewId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isConflict());
+    }
+}

--- a/src/test/java/com/idukbaduk/itseats/review/controller/ReviewReportControllerTest.java
+++ b/src/test/java/com/idukbaduk/itseats/review/controller/ReviewReportControllerTest.java
@@ -79,7 +79,7 @@ class ReviewReportControllerTest {
     }
 
     @Test
-    @DisplayName("가맹점주가 아니면 403 반환")
+    @DisplayName("가맹점주가 아니면 에러 발생")
     @WithMockUser(username = "owner1")
     void reportReview_notStoreOwner() throws Exception {
         // given
@@ -100,7 +100,7 @@ class ReviewReportControllerTest {
     }
 
     @Test
-    @DisplayName("리뷰가 없으면 404 반환")
+    @DisplayName("리뷰가 없으면 에러 발생")
     @WithMockUser(username = "owner1")
     void reportReview_reviewNotFound() throws Exception {
         // given
@@ -121,7 +121,7 @@ class ReviewReportControllerTest {
     }
 
     @Test
-    @DisplayName("중복 신고 시 409 반환")
+    @DisplayName("중복 신고 시 에러 발생")
     @WithMockUser(username = "owner1")
     void reportReview_alreadyReported() throws Exception {
         // given

--- a/src/test/java/com/idukbaduk/itseats/review/service/ReviewReportServiceTest.java
+++ b/src/test/java/com/idukbaduk/itseats/review/service/ReviewReportServiceTest.java
@@ -1,0 +1,207 @@
+package com.idukbaduk.itseats.review.service;
+
+import com.idukbaduk.itseats.member.entity.Member;
+import com.idukbaduk.itseats.member.error.MemberException;
+import com.idukbaduk.itseats.member.error.enums.MemberErrorCode;
+import com.idukbaduk.itseats.member.repository.MemberRepository;
+import com.idukbaduk.itseats.review.dto.ReviewReportRequest;
+import com.idukbaduk.itseats.review.dto.ReviewReportResponse;
+import com.idukbaduk.itseats.review.entity.Review;
+import com.idukbaduk.itseats.review.entity.ReviewReport;
+import com.idukbaduk.itseats.review.entity.enums.ReportStatus;
+import com.idukbaduk.itseats.review.error.ReviewErrorCode;
+import com.idukbaduk.itseats.review.error.ReviewException;
+import com.idukbaduk.itseats.review.repository.ReviewReportRepository;
+import com.idukbaduk.itseats.review.repository.ReviewRepository;
+import com.idukbaduk.itseats.store.entity.Store;
+import com.idukbaduk.itseats.store.error.StoreException;
+import com.idukbaduk.itseats.store.error.enums.StoreErrorCode;
+import com.idukbaduk.itseats.store.repository.StoreRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ReviewReportServiceTest {
+
+    @Mock
+    private ReviewReportRepository reviewReportRepository;
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @Mock
+    private ReviewRepository reviewRepository;
+
+    @Mock
+    private StoreRepository storeRepository;
+
+    @InjectMocks
+    private OwnerReviewService ownerReviewService;
+
+    @Test
+    @DisplayName("리뷰 신고 성공")
+    void reportReview_success() {
+        // given
+        String username = "owner1";
+        Long storeId = 10L;
+        Long reviewId = 100L;
+        ReviewReportRequest request = ReviewReportRequest.builder()
+                .reason("욕설")
+                .build();
+
+        Member member = Member.builder().memberId(1L).username(username).build();
+        Store store = Store.builder().storeId(storeId).member(member).build();
+        Review review = Review.builder().reviewId(reviewId).build();
+
+        given(memberRepository.findByUsername(username)).willReturn(Optional.of(member));
+        given(storeRepository.findById(storeId)).willReturn(Optional.of(store));
+        given(reviewRepository.findById(reviewId)).willReturn(Optional.of(review));
+        given(reviewReportRepository.existsByMember_MemberIdAndReview_ReviewId(member.getMemberId(), reviewId)).willReturn(false);
+        given(reviewReportRepository.save(any(ReviewReport.class)))
+                .willAnswer(invocation -> {
+                    ReviewReport saved = invocation.getArgument(0);
+                    return ReviewReport.builder()
+                            .reportId(999L)
+                            .member(saved.getMember())
+                            .review(saved.getReview())
+                            .reason(saved.getReason())
+                            .reportStatus(saved.getReportStatus())
+                            .build();
+                });
+
+        // when
+        ReviewReportResponse response = ownerReviewService.reportReview(username, storeId, reviewId, request);
+
+        // then
+        assertThat(response).isNotNull();
+        assertThat(response.getReporter()).isEqualTo(username);
+        assertThat(response.getReviewId()).isEqualTo(reviewId);
+        assertThat(response.getReason()).isEqualTo("욕설");
+        assertThat(response.getReportStatus()).isEqualTo(ReportStatus.ACCEPTED);
+    }
+
+    @Test
+    @DisplayName("가맹점주가 아니면 예외 발생")
+    void reportReview_notStoreOwner() {
+        // given
+        String username = "owner1";
+        Long storeId = 10L;
+        Long reviewId = 100L;
+        ReviewReportRequest request = ReviewReportRequest.builder()
+                .reason("욕설")
+                .build();
+
+        Member member = Member.builder().memberId(1L).username(username).build();
+        Member otherMember = Member.builder().memberId(2L).username("other").build();
+        Store store = Store.builder().storeId(storeId).member(otherMember).build();
+
+        given(memberRepository.findByUsername(username)).willReturn(Optional.of(member));
+        given(storeRepository.findById(storeId)).willReturn(Optional.of(store));
+
+        // when & then
+        assertThatThrownBy(() -> ownerReviewService.reportReview(username, storeId, reviewId, request))
+                .isInstanceOf(StoreException.class)
+                .hasMessageContaining(StoreErrorCode.NOT_STORE_OWNER.getMessage());
+    }
+
+    @Test
+    @DisplayName("리뷰가 없으면 예외 발생")
+    void reportReview_reviewNotFound() {
+        // given
+        String username = "owner1";
+        Long storeId = 10L;
+        Long reviewId = 100L;
+        ReviewReportRequest request = ReviewReportRequest.builder()
+                .reason("욕설")
+                .build();
+
+        Member member = Member.builder().memberId(1L).username(username).build();
+        Store store = Store.builder().storeId(storeId).member(member).build();
+
+        given(memberRepository.findByUsername(username)).willReturn(Optional.of(member));
+        given(storeRepository.findById(storeId)).willReturn(Optional.of(store));
+        given(reviewRepository.findById(reviewId)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> ownerReviewService.reportReview(username, storeId, reviewId, request))
+                .isInstanceOf(ReviewException.class)
+                .hasMessageContaining(ReviewErrorCode.REVIEW_NOT_FOUND.getMessage());
+    }
+
+    @Test
+    @DisplayName("중복 신고 시 예외 발생")
+    void reportReview_alreadyReported() {
+        // given
+        String username = "owner1";
+        Long storeId = 10L;
+        Long reviewId = 100L;
+        ReviewReportRequest request = ReviewReportRequest.builder()
+                .reason("욕설")
+                .build();
+
+        Member member = Member.builder().memberId(1L).username(username).build();
+        Store store = Store.builder().storeId(storeId).member(member).build();
+        Review review = Review.builder().reviewId(reviewId).build();
+
+        given(memberRepository.findByUsername(username)).willReturn(Optional.of(member));
+        given(storeRepository.findById(storeId)).willReturn(Optional.of(store));
+        given(reviewRepository.findById(reviewId)).willReturn(Optional.of(review));
+        given(reviewReportRepository.existsByMember_MemberIdAndReview_ReviewId(member.getMemberId(), reviewId)).willReturn(true);
+
+        // when & then
+        assertThatThrownBy(() -> ownerReviewService.reportReview(username, storeId, reviewId, request))
+                .isInstanceOf(ReviewException.class)
+                .hasMessageContaining(ReviewErrorCode.ALREADY_REPORTED.getMessage());
+    }
+
+    @Test
+    @DisplayName("신고자(멤버) 정보가 없으면 예외 발생")
+    void reportReview_memberNotFound() {
+        // given
+        String username = "owner1";
+        Long storeId = 10L;
+        Long reviewId = 100L;
+        ReviewReportRequest request = ReviewReportRequest.builder()
+                .reason("욕설")
+                .build();
+
+        given(memberRepository.findByUsername(username)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> ownerReviewService.reportReview(username, storeId, reviewId, request))
+                .isInstanceOf(MemberException.class)
+                .hasMessageContaining(MemberErrorCode.MEMBER_NOT_FOUND.getMessage());
+    }
+
+    @Test
+    @DisplayName("가맹점 정보가 없으면 예외 발생")
+    void reportReview_storeNotFound() {
+        // given
+        String username = "owner1";
+        Long storeId = 10L;
+        Long reviewId = 100L;
+        ReviewReportRequest request = ReviewReportRequest.builder()
+                .reason("욕설")
+                .build();
+
+        Member member = Member.builder().memberId(1L).username(username).build();
+        given(memberRepository.findByUsername(username)).willReturn(Optional.of(member));
+        given(storeRepository.findById(storeId)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> ownerReviewService.reportReview(username, storeId, reviewId, request))
+                .isInstanceOf(StoreException.class)
+                .hasMessageContaining(StoreErrorCode.STORE_NOT_FOUND.getMessage());
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

#181 
closes #181 
## 📝작업 내용
- [ ] `ReviewReport` 엔티티 작성, `ReportStatus` Enum 활용
- [ ] `ReviewReportRequest`, `ReviewReportResponse` 작성
- [ ] `OwnerReviewService`, `OwnerReviewController`에 리뷰 신고 메소드 추가
- [ ] 테스트 코드 작성 후 작동 확인 완료 

### 스크린샷 (선택)
<img width="424" alt="image" src="https://github.com/user-attachments/assets/9883635c-cdc6-4951-b4da-5dffd4f4e506" />
<img width="427" alt="image" src="https://github.com/user-attachments/assets/2224647f-7800-4e1e-8b89-2283c88e1c16" />

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 가맹점주가 특정 리뷰를 신고할 수 있는 API가 추가되었습니다. 리뷰 신고 시 사유를 입력할 수 있으며, 신고 결과가 응답으로 제공됩니다.

* **버그 수정**
  * 리뷰를 이미 신고한 경우, 중복 신고 시도 시 적절한 안내 메시지와 함께 요청이 거부됩니다.
  * 가맹점주가 아닌 사용자가 신고를 시도할 경우 접근이 제한됩니다.

* **테스트**
  * 리뷰 신고 기능에 대한 성공 및 다양한 실패 케이스(비소유자, 미존재 리뷰, 중복 신고, 회원 미존재, 가맹점 미존재 등)를 검증하는 테스트가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->