### PR TITLE
[Feature] 토스페이먼츠 결제 연동 및 토스 결제 승인 API 구현

### DIFF
--- a/src/main/java/com/idukbaduk/itseats/global/config/ClientConfig.java
+++ b/src/main/java/com/idukbaduk/itseats/global/config/ClientConfig.java
@@ -27,7 +27,7 @@ public class ClientConfig {
     private String tossBaseUrl;
 
     @Bean
-    public RestClient TossRestClient() {
+    public RestClient tossRestClient() {
         return RestClient.builder()
 //                .requestFactory(getRequestFactory())
                 .baseUrl(tossBaseUrl)

--- a/src/main/java/com/idukbaduk/itseats/global/config/ClientConfig.java
+++ b/src/main/java/com/idukbaduk/itseats/global/config/ClientConfig.java
@@ -29,7 +29,7 @@ public class ClientConfig {
     @Bean
     public RestClient TossRestClient() {
         return RestClient.builder()
-                .requestFactory(getRequestFactory())
+//                .requestFactory(getRequestFactory())
                 .baseUrl(tossBaseUrl)
                 .defaultHeader(HttpHeaders.AUTHORIZATION, AUTH_HEADER_PREFIX + getEncodedAuth())
                 .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
@@ -37,13 +37,13 @@ public class ClientConfig {
     }
 
     // TODO : Factory에 관해 고민해볼것
-    private ClientHttpRequestFactory getRequestFactory() {
-        HttpComponentsClientHttpRequestFactory factory = new HttpComponentsClientHttpRequestFactory();
-        factory.setConnectTimeout(CONNECT_TIMEOUT);
-        factory.setReadTimeout(READ_TIMEOUT);
-
-        return factory;
-    }
+//    private ClientHttpRequestFactory getRequestFactory() {
+//        HttpComponentsClientHttpRequestFactory factory = new HttpComponentsClientHttpRequestFactory();
+//        factory.setConnectTimeout(CONNECT_TIMEOUT);
+//        factory.setReadTimeout(READ_TIMEOUT);
+//
+//        return factory;
+//    }
 
     private String getEncodedAuth() {
         return Base64.getEncoder().encodeToString((secretKey + BASIC_DELIMITER).getBytes(StandardCharsets.UTF_8));

--- a/src/main/java/com/idukbaduk/itseats/global/config/ClientConfig.java
+++ b/src/main/java/com/idukbaduk/itseats/global/config/ClientConfig.java
@@ -1,0 +1,51 @@
+package com.idukbaduk.itseats.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.client.ClientHttpRequestFactory;
+import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
+import org.springframework.web.client.RestClient;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
+@Configuration
+public class ClientConfig {
+
+    private static final String AUTH_HEADER_PREFIX = "Basic ";
+    private static final String BASIC_DELIMITER = ":";
+    private static final int CONNECT_TIMEOUT = 5000;
+    private static final int READ_TIMEOUT = 30000;
+
+    @Value("${payment.toss.key}")
+    private String secretKey;
+
+    @Value("${payment.toss.url}")
+    private String tossBaseUrl;
+
+    @Bean
+    public RestClient TossRestClient() {
+        return RestClient.builder()
+                .requestFactory(getRequestFactory())
+                .baseUrl(tossBaseUrl)
+                .defaultHeader(HttpHeaders.AUTHORIZATION, AUTH_HEADER_PREFIX + getEncodedAuth())
+                .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                .build();
+    }
+
+    // TODO : Factory에 관해 고민해볼것
+    private ClientHttpRequestFactory getRequestFactory() {
+        HttpComponentsClientHttpRequestFactory factory = new HttpComponentsClientHttpRequestFactory();
+        factory.setConnectTimeout(CONNECT_TIMEOUT);
+        factory.setReadTimeout(READ_TIMEOUT);
+
+        return factory;
+    }
+
+    private String getEncodedAuth() {
+        return Base64.getEncoder().encodeToString((secretKey + BASIC_DELIMITER).getBytes(StandardCharsets.UTF_8));
+    }
+}

--- a/src/main/java/com/idukbaduk/itseats/global/config/ClientConfig.java
+++ b/src/main/java/com/idukbaduk/itseats/global/config/ClientConfig.java
@@ -6,7 +6,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.http.client.ClientHttpRequestFactory;
-import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.web.client.RestClient;
 
 import java.nio.charset.StandardCharsets;
@@ -29,21 +29,20 @@ public class ClientConfig {
     @Bean
     public RestClient tossRestClient() {
         return RestClient.builder()
-//                .requestFactory(getRequestFactory())
+                .requestFactory(getRequestFactory())
                 .baseUrl(tossBaseUrl)
                 .defaultHeader(HttpHeaders.AUTHORIZATION, AUTH_HEADER_PREFIX + getEncodedAuth())
                 .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
                 .build();
     }
 
-    // TODO : Factory에 관해 고민해볼것
-//    private ClientHttpRequestFactory getRequestFactory() {
-//        HttpComponentsClientHttpRequestFactory factory = new HttpComponentsClientHttpRequestFactory();
-//        factory.setConnectTimeout(CONNECT_TIMEOUT);
-//        factory.setReadTimeout(READ_TIMEOUT);
-//
-//        return factory;
-//    }
+    private ClientHttpRequestFactory getRequestFactory() {
+        SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
+        factory.setConnectTimeout(CONNECT_TIMEOUT);
+        factory.setReadTimeout(READ_TIMEOUT);
+
+        return factory;
+    }
 
     private String getEncodedAuth() {
         return Base64.getEncoder().encodeToString((secretKey + BASIC_DELIMITER).getBytes(StandardCharsets.UTF_8));

--- a/src/main/java/com/idukbaduk/itseats/payment/controller/PaymentController.java
+++ b/src/main/java/com/idukbaduk/itseats/payment/controller/PaymentController.java
@@ -17,7 +17,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/api/orders")
+@RequestMapping("/api/payments")
 @RequiredArgsConstructor
 public class PaymentController {
 

--- a/src/main/java/com/idukbaduk/itseats/payment/controller/PaymentController.java
+++ b/src/main/java/com/idukbaduk/itseats/payment/controller/PaymentController.java
@@ -9,6 +9,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -31,11 +32,12 @@ public class PaymentController {
         );
     }
 
-    @PostMapping("/confirm")
+    @PostMapping("/{paymentId}/confirm")
     public ResponseEntity<BaseResponse> confirmPayment(
             @AuthenticationPrincipal UserDetails userDetails,
+            @PathVariable Long paymentId,
             @RequestBody PaymentConfirmRequest paymentConfirmRequest) {
-        paymentService.confirmPayment(userDetails.getUsername(), paymentConfirmRequest);
+        paymentService.confirmPayment(userDetails.getUsername(), paymentId, paymentConfirmRequest);
         return BaseResponse.toResponseEntity(PaymentResponse.CONFIRM_PAYMENT_SUCCESS);
     }
 }

--- a/src/main/java/com/idukbaduk/itseats/payment/controller/PaymentController.java
+++ b/src/main/java/com/idukbaduk/itseats/payment/controller/PaymentController.java
@@ -35,9 +35,7 @@ public class PaymentController {
     public ResponseEntity<BaseResponse> confirmPayment(
             @AuthenticationPrincipal UserDetails userDetails,
             @RequestBody PaymentConfirmRequest paymentConfirmRequest) {
-        return BaseResponse.toResponseEntity(
-                PaymentResponse.CONFIRM_PAYMENT_SUCCESS,
-                paymentService.confirmPayment(userDetails.getUsername(), paymentConfirmRequest)
-        );
+        paymentService.confirmPayment(userDetails.getUsername(), paymentConfirmRequest);
+        return BaseResponse.toResponseEntity(PaymentResponse.CONFIRM_PAYMENT_SUCCESS);
     }
 }

--- a/src/main/java/com/idukbaduk/itseats/payment/controller/PaymentController.java
+++ b/src/main/java/com/idukbaduk/itseats/payment/controller/PaymentController.java
@@ -1,6 +1,7 @@
 package com.idukbaduk.itseats.payment.controller;
 
 import com.idukbaduk.itseats.global.response.BaseResponse;
+import com.idukbaduk.itseats.payment.dto.PaymentConfirmRequest;
 import com.idukbaduk.itseats.payment.dto.PaymentInfoRequest;
 import com.idukbaduk.itseats.payment.dto.enums.PaymentResponse;
 import com.idukbaduk.itseats.payment.service.PaymentService;
@@ -27,6 +28,16 @@ public class PaymentController {
         return BaseResponse.toResponseEntity(
                 PaymentResponse.CREATE_PAYMENT_SUCCESS,
                 paymentService.createPayment(userDetails.getUsername(), paymentInfoRequest)
+        );
+    }
+
+    @PostMapping("/confirm")
+    public ResponseEntity<BaseResponse> confirmPayment(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @RequestBody PaymentConfirmRequest paymentConfirmRequest) {
+        return BaseResponse.toResponseEntity(
+                PaymentResponse.CONFIRM_PAYMENT_SUCCESS,
+                paymentService.confirmPayment(userDetails.getUsername(), paymentConfirmRequest)
         );
     }
 }

--- a/src/main/java/com/idukbaduk/itseats/payment/controller/PaymentController.java
+++ b/src/main/java/com/idukbaduk/itseats/payment/controller/PaymentController.java
@@ -5,6 +5,7 @@ import com.idukbaduk.itseats.payment.dto.PaymentConfirmRequest;
 import com.idukbaduk.itseats.payment.dto.PaymentInfoRequest;
 import com.idukbaduk.itseats.payment.dto.enums.PaymentResponse;
 import com.idukbaduk.itseats.payment.service.PaymentService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -36,7 +37,7 @@ public class PaymentController {
     public ResponseEntity<BaseResponse> confirmPayment(
             @AuthenticationPrincipal UserDetails userDetails,
             @PathVariable Long paymentId,
-            @RequestBody PaymentConfirmRequest paymentConfirmRequest) {
+            @RequestBody @Valid PaymentConfirmRequest paymentConfirmRequest) {
         paymentService.confirmPayment(userDetails.getUsername(), paymentId, paymentConfirmRequest);
         return BaseResponse.toResponseEntity(PaymentResponse.CONFIRM_PAYMENT_SUCCESS);
     }

--- a/src/main/java/com/idukbaduk/itseats/payment/dto/PaymentClientResponse.java
+++ b/src/main/java/com/idukbaduk/itseats/payment/dto/PaymentClientResponse.java
@@ -1,0 +1,14 @@
+package com.idukbaduk.itseats.payment.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class PaymentClientResponse {
+
+    private String paymentKey;
+    private String orderId;
+    private Long totalAmount;
+    private String status;
+}

--- a/src/main/java/com/idukbaduk/itseats/payment/dto/PaymentConfirmRequest.java
+++ b/src/main/java/com/idukbaduk/itseats/payment/dto/PaymentConfirmRequest.java
@@ -1,0 +1,17 @@
+package com.idukbaduk.itseats.payment.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PaymentConfirmRequest {
+
+    private String paymentKey;
+    private String orderId;
+    private Long amount;
+}

--- a/src/main/java/com/idukbaduk/itseats/payment/dto/PaymentConfirmRequest.java
+++ b/src/main/java/com/idukbaduk/itseats/payment/dto/PaymentConfirmRequest.java
@@ -1,5 +1,7 @@
 package com.idukbaduk.itseats.payment.dto;
 
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -11,7 +13,13 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class PaymentConfirmRequest {
 
+    @NotNull(message = "토스 결제 키는 필수값입니다.")
     private String paymentKey;
+
+    @NotNull(message = "토스 주문 아이디는 필수값입니다.")
     private String orderId;
+
+    @NotNull(message = "총 금액은 필수값입니다.")
+    @Positive(message = "총 금액은 양수값이어야 합니다.")
     private Long amount;
 }

--- a/src/main/java/com/idukbaduk/itseats/payment/dto/PaymentInfoRequest.java
+++ b/src/main/java/com/idukbaduk/itseats/payment/dto/PaymentInfoRequest.java
@@ -17,7 +17,6 @@ public class PaymentInfoRequest {
     private List<Long> coupons;
     private int totalCost;
     private String paymentMethod;
-    private String paymentStatus;
     private String storeRequest;
     private String riderRequest;
 }

--- a/src/main/java/com/idukbaduk/itseats/payment/dto/PaymentInfoRequest.java
+++ b/src/main/java/com/idukbaduk/itseats/payment/dto/PaymentInfoRequest.java
@@ -15,7 +15,7 @@ public class PaymentInfoRequest {
 
     private Long orderId;
     private List<Long> coupons;
-    private int totalCost;
+    private Long totalCost;
     private String paymentMethod;
     private String storeRequest;
     private String riderRequest;

--- a/src/main/java/com/idukbaduk/itseats/payment/dto/enums/PaymentResponse.java
+++ b/src/main/java/com/idukbaduk/itseats/payment/dto/enums/PaymentResponse.java
@@ -7,7 +7,8 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum PaymentResponse implements Response {
 
-    CREATE_PAYMENT_SUCCESS(HttpStatus.CREATED, "결제 성공");
+    CREATE_PAYMENT_SUCCESS(HttpStatus.CREATED, "결제 생성 성공"),
+    CONFIRM_PAYMENT_SUCCESS(HttpStatus.OK, "결제 승인 성공");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/idukbaduk/itseats/payment/entity/Payment.java
+++ b/src/main/java/com/idukbaduk/itseats/payment/entity/Payment.java
@@ -62,4 +62,16 @@ public class Payment extends BaseEntity {
 
     @Column(name = "rider_request")
     private String riderRequest;
+
+    @Column(name = "toss_payment_key")
+    private String tossPaymentKey;
+
+    @Column(name = "toss_order_id")
+    private String tossOrderId;
+
+    public void confirm(String paymentKey, String orderId) {
+        this.tossPaymentKey = paymentKey;
+        this.tossOrderId = orderId;
+        this.paymentStatus = PaymentStatus.COMPLETED;
+    }
 }

--- a/src/main/java/com/idukbaduk/itseats/payment/entity/Payment.java
+++ b/src/main/java/com/idukbaduk/itseats/payment/entity/Payment.java
@@ -47,7 +47,7 @@ public class Payment extends BaseEntity {
     private int discountValue;
 
     @Column(name = "total_cost", nullable = false)
-    private int totalCost;
+    private Long totalCost;
 
     @Enumerated(EnumType.STRING)
     @Column(name = "payment_method", nullable = false)

--- a/src/main/java/com/idukbaduk/itseats/payment/entity/enums/PaymentStatus.java
+++ b/src/main/java/com/idukbaduk/itseats/payment/entity/enums/PaymentStatus.java
@@ -2,6 +2,7 @@ package com.idukbaduk.itseats.payment.entity.enums;
 
 public enum PaymentStatus {
 
+    PENDING,
     COMPLETED,
     CANCELED,
     FAILED

--- a/src/main/java/com/idukbaduk/itseats/payment/error/enums/PaymentConfirmErrorCode.java
+++ b/src/main/java/com/idukbaduk/itseats/payment/error/enums/PaymentConfirmErrorCode.java
@@ -7,7 +7,8 @@ import org.springframework.http.HttpStatus;
 
 @Getter
 @RequiredArgsConstructor
-public class PaymentConfirmErrorCode implements ErrorCode {
+public enum PaymentConfirmErrorCode implements ErrorCode {
+    ;
 
     private HttpStatus httpStatus;
     private String message;

--- a/src/main/java/com/idukbaduk/itseats/payment/error/enums/PaymentConfirmErrorCode.java
+++ b/src/main/java/com/idukbaduk/itseats/payment/error/enums/PaymentConfirmErrorCode.java
@@ -1,0 +1,24 @@
+package com.idukbaduk.itseats.payment.error.enums;
+
+import com.idukbaduk.itseats.global.error.core.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public class PaymentConfirmErrorCode implements ErrorCode {
+
+    private HttpStatus httpStatus;
+    private String message;
+
+    @Override
+    public HttpStatus getStatus() {
+        return httpStatus;
+    }
+
+    @Override
+    public String getMessage() {
+        return "[PAYMENT CONFIRM ERROR] " + message;
+    }
+}

--- a/src/main/java/com/idukbaduk/itseats/payment/error/enums/PaymentErrorCode.java
+++ b/src/main/java/com/idukbaduk/itseats/payment/error/enums/PaymentErrorCode.java
@@ -7,7 +7,10 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum PaymentErrorCode implements ErrorCode {
 
-    PAYMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "결제 조회 실패"),;
+    PAYMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "결제 조회 실패"),
+    TOSS_PAYMENT_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "토스 결제 서버 에러"),
+    PAYMENT_AMOUNT_MISMATCH(HttpStatus.BAD_REQUEST, "요청 금액과 실제 금액이 다릅니다."),
+    PAYMENT_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "결제 실패. 다시 시도해주세요.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/idukbaduk/itseats/payment/repository/PaymentRepository.java
+++ b/src/main/java/com/idukbaduk/itseats/payment/repository/PaymentRepository.java
@@ -3,6 +3,8 @@ package com.idukbaduk.itseats.payment.repository;
 import com.idukbaduk.itseats.order.entity.Order;
 import com.idukbaduk.itseats.payment.entity.Payment;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
@@ -11,4 +13,11 @@ import java.util.Optional;
 public interface PaymentRepository extends JpaRepository<Payment, Long> {
 
     Optional<Payment> findByOrder(Order order);
+
+    @Query("""
+        SELECT p
+        FROM Payment p
+        WHERE p.member.username = :username
+    """)
+    Optional<Payment> findByUsername(@Param("username") String username);
 }

--- a/src/main/java/com/idukbaduk/itseats/payment/repository/PaymentRepository.java
+++ b/src/main/java/com/idukbaduk/itseats/payment/repository/PaymentRepository.java
@@ -18,6 +18,10 @@ public interface PaymentRepository extends JpaRepository<Payment, Long> {
         SELECT p
         FROM Payment p
         WHERE p.member.username = :username
+          AND p.paymentId = :paymentId
     """)
-    Optional<Payment> findByUsername(@Param("username") String username);
+    Optional<Payment> findByPaymentIdAndUsername(
+            @Param("username") String username,
+            @Param("paymentId") Long paymentId
+    );
 }

--- a/src/main/java/com/idukbaduk/itseats/payment/service/PaymentService.java
+++ b/src/main/java/com/idukbaduk/itseats/payment/service/PaymentService.java
@@ -49,7 +49,7 @@ public class PaymentService {
                 .discountValue(0)
                 .totalCost(paymentInfoRequest.getTotalCost())
                 .paymentMethod(PaymentMethod.valueOf(paymentInfoRequest.getPaymentMethod()))
-                .paymentStatus(PaymentStatus.valueOf(paymentInfoRequest.getPaymentStatus()))
+                .paymentStatus(PaymentStatus.PENDING)
                 .storeRequest(paymentInfoRequest.getStoreRequest())
                 .riderRequest(paymentInfoRequest.getRiderRequest())
                 .build();

--- a/src/main/java/com/idukbaduk/itseats/payment/service/PaymentService.java
+++ b/src/main/java/com/idukbaduk/itseats/payment/service/PaymentService.java
@@ -66,8 +66,8 @@ public class PaymentService {
                 .orElseThrow(() -> new PaymentException(PaymentErrorCode.PAYMENT_NOT_FOUND));
     }
 
-    public void confirmPayment(String username, PaymentConfirmRequest paymentConfirmRequest) {
-        Payment payment = paymentRepository.findByUsername(username)
+    public void confirmPayment(String username, Long paymentId, PaymentConfirmRequest paymentConfirmRequest) {
+        Payment payment = paymentRepository.findByPaymentIdAndUsername(username, paymentId)
                 .orElseThrow(() -> new PaymentException(PaymentErrorCode.PAYMENT_NOT_FOUND));
 
         PaymentClientResponse clientResponse = paymentClient.confirmPayment(paymentConfirmRequest);

--- a/src/main/java/com/idukbaduk/itseats/payment/service/PaymentService.java
+++ b/src/main/java/com/idukbaduk/itseats/payment/service/PaymentService.java
@@ -66,7 +66,7 @@ public class PaymentService {
                 .orElseThrow(() -> new PaymentException(PaymentErrorCode.PAYMENT_NOT_FOUND));
     }
 
-    public PaymentClientResponse confirmPayment(String username, PaymentConfirmRequest paymentConfirmRequest) {
+    public void confirmPayment(String username, PaymentConfirmRequest paymentConfirmRequest) {
         Payment payment = paymentRepository.findByUsername(username)
                 .orElseThrow(() -> new PaymentException(PaymentErrorCode.PAYMENT_NOT_FOUND));
 
@@ -75,20 +75,11 @@ public class PaymentService {
 
         payment.confirm(clientResponse.getPaymentKey(), clientResponse.getOrderId());
         paymentRepository.save(payment);
-
-        return buildPaymentClientResponse(payment);
     }
 
     private void validateAmount(Long totalCost, Long tossAmount) {
         if (!totalCost.equals(tossAmount)) {
             throw new PaymentException(PaymentErrorCode.PAYMENT_AMOUNT_MISMATCH);
         }
-    }
-
-    private PaymentClientResponse buildPaymentClientResponse(Payment payment) {
-        return PaymentClientResponse.builder()
-                .paymentKey(payment.getTossPaymentKey())
-                .orderId(payment.getTossOrderId())
-                .build();
     }
 }

--- a/src/main/java/com/idukbaduk/itseats/payment/service/client/PaymentClient.java
+++ b/src/main/java/com/idukbaduk/itseats/payment/service/client/PaymentClient.java
@@ -15,6 +15,8 @@ import java.util.Objects;
 @RequiredArgsConstructor
 public class PaymentClient {
 
+    private static final String PAYMENT_SUCCESS_STATUS = "DONE";
+
     private final RestClient restClient;
 
     public PaymentClientResponse confirmPayment(PaymentConfirmRequest confirmRequest) {
@@ -31,7 +33,7 @@ public class PaymentClient {
     }
 
     private void validatePaymentStatus(String status) {
-        if (!status.equals("DONE")) {
+        if (!PAYMENT_SUCCESS_STATUS.equals(status)) {
             throw new PaymentException(PaymentErrorCode.PAYMENT_FAIL);
         }
     }

--- a/src/main/java/com/idukbaduk/itseats/payment/service/client/PaymentClient.java
+++ b/src/main/java/com/idukbaduk/itseats/payment/service/client/PaymentClient.java
@@ -39,10 +39,14 @@ public class PaymentClient {
         }
     }
 
-    private void handlePaymentError(ClientHttpResponse response) throws IOException {
-        byte[] body = response.getBody().readAllBytes();
-        PaymentConfirmErrorCode errorCode = objectMapper.readValue(body, PaymentConfirmErrorCode.class);
-        throw new PaymentException(errorCode);
+    private void handlePaymentError(ClientHttpResponse response){
+        try {
+            byte[] body = response.getBody().readAllBytes();
+            PaymentConfirmErrorCode errorCode = objectMapper.readValue(body, PaymentConfirmErrorCode.class);
+            throw new PaymentException(errorCode);
+        } catch(IOException e) {
+            throw new PaymentException(PaymentErrorCode.TOSS_PAYMENT_SERVER_ERROR);
+        }
     }
 
     private void validatePaymentStatus(String status) {

--- a/src/main/java/com/idukbaduk/itseats/payment/service/client/PaymentClient.java
+++ b/src/main/java/com/idukbaduk/itseats/payment/service/client/PaymentClient.java
@@ -1,0 +1,28 @@
+package com.idukbaduk.itseats.payment.service.client;
+
+import com.idukbaduk.itseats.payment.dto.PaymentClientResponse;
+import com.idukbaduk.itseats.payment.dto.PaymentConfirmRequest;
+import com.idukbaduk.itseats.payment.error.PaymentException;
+import com.idukbaduk.itseats.payment.error.enums.PaymentErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.ResourceAccessException;
+import org.springframework.web.client.RestClient;
+
+@Component
+@RequiredArgsConstructor
+public class PaymentClient {
+
+    private final RestClient restClient;
+
+    public PaymentClientResponse confirmPayment(PaymentConfirmRequest confirmRequest) {
+        try {
+            return restClient.post().uri("/confirm")
+                    .body(confirmRequest)
+                    .retrieve()
+                    .body(PaymentClientResponse.class);
+        } catch (ResourceAccessException e) {
+            throw new PaymentException(PaymentErrorCode.TOSS_PAYMENT_SERVER_ERROR);
+        }
+    }
+}

--- a/src/main/java/com/idukbaduk/itseats/payment/service/client/PaymentClient.java
+++ b/src/main/java/com/idukbaduk/itseats/payment/service/client/PaymentClient.java
@@ -1,14 +1,18 @@
 package com.idukbaduk.itseats.payment.service.client;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.idukbaduk.itseats.payment.dto.PaymentClientResponse;
 import com.idukbaduk.itseats.payment.dto.PaymentConfirmRequest;
 import com.idukbaduk.itseats.payment.error.PaymentException;
+import com.idukbaduk.itseats.payment.error.enums.PaymentConfirmErrorCode;
 import com.idukbaduk.itseats.payment.error.enums.PaymentErrorCode;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.client.ClientHttpResponse;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.ResourceAccessException;
 import org.springframework.web.client.RestClient;
 
+import java.io.IOException;
 import java.util.Objects;
 
 @Component
@@ -18,18 +22,27 @@ public class PaymentClient {
     private static final String PAYMENT_SUCCESS_STATUS = "DONE";
 
     private final RestClient restClient;
+    private final ObjectMapper objectMapper;
 
     public PaymentClientResponse confirmPayment(PaymentConfirmRequest confirmRequest) {
         try {
             PaymentClientResponse clientResponse =  restClient.post().uri("/confirm")
                     .body(confirmRequest)
                     .retrieve()
+                    .onStatus(httpStatus -> httpStatus.is4xxClientError() || httpStatus.is5xxServerError(),
+                            (request, response) -> handlePaymentError(response))
                     .body(PaymentClientResponse.class);
             validatePaymentStatus(Objects.requireNonNull(clientResponse).getStatus());
             return clientResponse;
         } catch (ResourceAccessException e) {
             throw new PaymentException(PaymentErrorCode.TOSS_PAYMENT_SERVER_ERROR);
         }
+    }
+
+    private void handlePaymentError(ClientHttpResponse response) throws IOException {
+        byte[] body = response.getBody().readAllBytes();
+        PaymentConfirmErrorCode errorCode = objectMapper.readValue(body, PaymentConfirmErrorCode.class);
+        throw new PaymentException(errorCode);
     }
 
     private void validatePaymentStatus(String status) {

--- a/src/main/java/com/idukbaduk/itseats/payment/service/client/PaymentClient.java
+++ b/src/main/java/com/idukbaduk/itseats/payment/service/client/PaymentClient.java
@@ -32,7 +32,9 @@ public class PaymentClient {
                     .onStatus(httpStatus -> httpStatus.is4xxClientError() || httpStatus.is5xxServerError(),
                             (request, response) -> handlePaymentError(response))
                     .body(PaymentClientResponse.class);
-            validatePaymentStatus(Objects.requireNonNull(clientResponse).getStatus());
+
+            validatePaymentClientResponse(clientResponse);
+            validatePaymentStatus(clientResponse.getStatus());
             return clientResponse;
         } catch (ResourceAccessException e) {
             throw new PaymentException(PaymentErrorCode.TOSS_PAYMENT_SERVER_ERROR);
@@ -45,6 +47,12 @@ public class PaymentClient {
             PaymentConfirmErrorCode errorCode = objectMapper.readValue(body, PaymentConfirmErrorCode.class);
             throw new PaymentException(errorCode);
         } catch(IOException e) {
+            throw new PaymentException(PaymentErrorCode.TOSS_PAYMENT_SERVER_ERROR);
+        }
+    }
+
+    private void validatePaymentClientResponse(PaymentClientResponse clientResponse) {
+        if (clientResponse == null) {
             throw new PaymentException(PaymentErrorCode.TOSS_PAYMENT_SERVER_ERROR);
         }
     }

--- a/src/main/java/com/idukbaduk/itseats/payment/service/client/PaymentClient.java
+++ b/src/main/java/com/idukbaduk/itseats/payment/service/client/PaymentClient.java
@@ -9,6 +9,8 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.client.ResourceAccessException;
 import org.springframework.web.client.RestClient;
 
+import java.util.Objects;
+
 @Component
 @RequiredArgsConstructor
 public class PaymentClient {
@@ -17,12 +19,20 @@ public class PaymentClient {
 
     public PaymentClientResponse confirmPayment(PaymentConfirmRequest confirmRequest) {
         try {
-            return restClient.post().uri("/confirm")
+            PaymentClientResponse clientResponse =  restClient.post().uri("/confirm")
                     .body(confirmRequest)
                     .retrieve()
                     .body(PaymentClientResponse.class);
+            validatePaymentStatus(Objects.requireNonNull(clientResponse).getStatus());
+            return clientResponse;
         } catch (ResourceAccessException e) {
             throw new PaymentException(PaymentErrorCode.TOSS_PAYMENT_SERVER_ERROR);
+        }
+    }
+
+    private void validatePaymentStatus(String status) {
+        if (!status.equals("DONE")) {
+            throw new PaymentException(PaymentErrorCode.PAYMENT_FAIL);
         }
     }
 }

--- a/src/test/java/com/idukbaduk/itseats/payment/service/PaymentServiceTest.java
+++ b/src/test/java/com/idukbaduk/itseats/payment/service/PaymentServiceTest.java
@@ -63,7 +63,7 @@ class PaymentServiceTest {
 
         paymentInfoRequest = PaymentInfoRequest.builder()
                 .orderId(1L)
-                .totalCost(10000)
+                .totalCost(10000L)
                 .paymentMethod(PaymentMethod.COUPAY.name())
                 .storeRequest("맛있게 만들어주세요")
                 .riderRequest("문 앞에 두고 가주세요")

--- a/src/test/java/com/idukbaduk/itseats/payment/service/PaymentServiceTest.java
+++ b/src/test/java/com/idukbaduk/itseats/payment/service/PaymentServiceTest.java
@@ -65,7 +65,6 @@ class PaymentServiceTest {
                 .orderId(1L)
                 .totalCost(10000)
                 .paymentMethod(PaymentMethod.COUPAY.name())
-                .paymentStatus(PaymentStatus.COMPLETED.name())
                 .storeRequest("맛있게 만들어주세요")
                 .riderRequest("문 앞에 두고 가주세요")
                 .build();
@@ -95,7 +94,7 @@ class PaymentServiceTest {
         assertThat(savedPayment.getOrder()).isEqualTo(order);
         assertThat(savedPayment.getTotalCost()).isEqualTo(paymentInfoRequest.getTotalCost());
         assertThat(savedPayment.getPaymentMethod()).isEqualTo(PaymentMethod.valueOf(paymentInfoRequest.getPaymentMethod()));
-        assertThat(savedPayment.getPaymentStatus()).isEqualTo(PaymentStatus.valueOf(paymentInfoRequest.getPaymentStatus()));
+        assertThat(savedPayment.getPaymentStatus()).isEqualTo(PaymentStatus.PENDING);
         assertThat(savedPayment.getStoreRequest()).isEqualTo(paymentInfoRequest.getStoreRequest());
         assertThat(savedPayment.getRiderRequest()).isEqualTo(paymentInfoRequest.getRiderRequest());
     }


### PR DESCRIPTION
## #️⃣연관된 이슈

#169 

## 📝작업 내용

- [x] 외부 API 연동 설정
- [x] 토스 결제 플로우 이해
- [x] 토스 연동

### 외부 API 연동 설정

- `RestClient`를 사용하여 외부 API를 호출하기 위해 적절한 Config 파일을 만들었습니다.
   - Timeout 관련된 설정은 `SimpleClientHttpRequestFactory`로 진행하였습니다.

### 토스 결제 플로우

1. 우리 서버의 `Payment` 객체 생성 (`/api/orders`)
   - `Payment` 객체를 생성할 때 `PaymentStatus` 상태를 `PENDING`으로 생성
2. 프론트엔드에서 결제 창 진입
   - 토스 결제 API에 필요한 랜덤 `orderId` 값 등은 프론트에서 생성
3. 프론트엔드에서 결제 승인 요청 (`/api/orders/confirm`)
4. 백엔드에서 토스페이먼츠 서버로 결제 승인 요청 전송 (`https://api.tosspayments.com/v1/payments/confirm`)
5. 결과에 따라 프론트엔드로 적절한 응답 반환
> 토스 결제 API 전체 플로우 참고
> ![image](https://github.com/user-attachments/assets/9cf32dd7-0748-454e-89df-53d77eca5496)

### 결제 승인 API

- `/api/orders/confirm`으로 결제 승인 API 접근 가능
- 토스페이먼츠 결제 승인 API 사용시 나올 수 있는 에러 코드 매핑 (추후 수정 가능)

## 👀참고사항

토스 결제 API는 프론트엔드를 통해 테스트를 진행할 수 있어서 아직 테스트는 진행하지 못했습니다. 결제 화면 구성이 완료된 이후 테스트/리팩토링 예정입니다.

## 💬리뷰 요구사항

- 현재 `Payment` 객체에 토스 결제 관련 필드를 `tossPaymentKey`, `tossOrderId` 이렇게 넣어주고 있는데, 아래 링크 확인 후 추가로 저장하면 좋을 거 같은 필드가 있으면 알려주세요!
[토스 결제 승인 API 문서](https://docs.tosspayments.com/reference#결제-승인)
- 결제 취소 API 관련해서도 구현하는게 좋을까요? 만약 구현해야 한다면 새로운 이슈에서 작업하도록 하겠습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit


* **신규 기능**
  * 결제 승인 요청을 위한 새로운 API 엔드포인트(/api/payments/{paymentId}/confirm) 추가.
  * 결제 승인 요청 및 응답을 위한 DTO(PaymentConfirmRequest, PaymentClientResponse) 및 결제 클라이언트(PaymentClient) 도입.
  * 결제 상태에 PENDING 추가 및 Toss 결제 관련 정보 필드(tossPaymentKey, tossOrderId) 추가.
  * 사용자명과 결제 ID로 결제 정보를 조회하는 기능 추가.
  * 외부 결제 서버와의 통신 설정 및 기본 헤더 구성 추가.

* **버그 수정**
  * 결제 금액 타입을 int에서 Long으로 변경하여 금액 처리의 정확성 향상.
  * 결제 생성 시 결제 상태가 항상 PENDING으로 초기화되도록 수정.
  * 결제 금액 불일치 시 예외 처리 강화.

* **기타**
  * 결제 오류 코드 및 응답 메시지 확장(결제 금액 불일치, 결제 실패, Toss 서버 오류 등).
  * 결제 성공 응답 메시지 세분화(결제 생성 성공, 결제 승인 성공).
  * 테스트 코드에서 변경된 필드 및 상태 반영.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->