### PR TITLE
[Feature] 더미데이터 생성을 위한 이미지 링크 업로드 기능

### DIFF
--- a/src/main/java/com/idukbaduk/itseats/menu/service/MenuMediaService.java
+++ b/src/main/java/com/idukbaduk/itseats/menu/service/MenuMediaService.java
@@ -14,6 +14,7 @@ import org.springframework.web.multipart.MultipartFile;
 import software.amazon.awssdk.core.exception.SdkException;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -91,7 +92,11 @@ public class MenuMediaService {
     private List<MenuImage> saveMenuImages(Menu menu, List<MultipartFile> images) throws IOException {
         List<MenuImage> menuImages = new ArrayList<>();
         for (int i = 0; i < images.size(); i++) {
-            String imageUrl = s3Utils.uploadFileAndGetUrl(PATH, images.get(i));
+            
+            String imageUrl = "text/plain".equalsIgnoreCase(images.get(i).getContentType())
+                    ? new String(images.get(i).getBytes(), StandardCharsets.UTF_8).trim() // 이미지 링크 업로드
+                    : s3Utils.uploadFileAndGetUrl(PATH, images.get(i)); // 이미지 파일 업로드
+
             MenuImage menuImage = MenuImage.builder()
                     .menu(menu)
                     .imageUrl(imageUrl)

--- a/src/main/java/com/idukbaduk/itseats/store/service/StoreMediaService.java
+++ b/src/main/java/com/idukbaduk/itseats/store/service/StoreMediaService.java
@@ -14,7 +14,9 @@ import org.springframework.web.multipart.MultipartFile;
 import software.amazon.awssdk.core.exception.SdkException;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
@@ -90,13 +92,18 @@ public class StoreMediaService {
     private List<StoreImage> saveStoreImages(Store store, List<MultipartFile> images) throws IOException {
         List<StoreImage> storeImages = new ArrayList<>();
         for (int i = 0; i < images.size(); i++) {
-            String imageUrl = s3Utils.uploadFileAndGetUrl(PATH, images.get(i));
+
+            String imageUrl = "text/plain".equalsIgnoreCase(images.get(i).getContentType())
+                    ? new String(images.get(i).getBytes(), StandardCharsets.UTF_8).trim() // 이미지 링크 업로드
+                    : s3Utils.uploadFileAndGetUrl(PATH, images.get(i)); // 이미지 파일 업로드
+
             StoreImage storeImage = StoreImage.builder()
                     .store(store)
                     .imageUrl(imageUrl)
                     .displayOrder(i)
                     .build();
             storeImages.add(storeImage);
+
         }
         return storeImageRepository.saveAll(storeImages);
     }


### PR DESCRIPTION
## #️⃣연관된 이슈

#203 
closes #203

## 📝작업 내용

더미데이터 생성을 위한 이미지 링크 업로드 기능을 추가합니다.

300x200 png 파일 30만개만 업로드해도 15GB의 용량이 소요될 걸로 예상되어 이미지 링크 업로드 기능을 통해 더미데이터 간 이미지를 공유하도록 합니다.

가맹점 추가 및 메뉴 설정의 이미지 업로드에 대해 적용합니다.


## 💬리뷰 요구사항(선택)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 이미지 등록 시, 이미지 파일뿐만 아니라 텍스트 파일로 이미지 URL을 직접 입력하여 등록할 수 있는 기능이 추가되었습니다.  
  * 메뉴 및 매장 이미지 등록 시 두 가지 방식(이미지 파일 업로드 또는 URL 입력)이 모두 지원됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->