### PR TITLE
[Feature] 내 쿠폰목록 조회 API 구현

### DIFF
--- a/src/main/java/com/idukbaduk/itseats/coupon/controller/CouponController.java
+++ b/src/main/java/com/idukbaduk/itseats/coupon/controller/CouponController.java
@@ -1,0 +1,29 @@
+package com.idukbaduk.itseats.coupon.controller;
+
+import com.idukbaduk.itseats.coupon.dto.MyCouponListResponse;
+import com.idukbaduk.itseats.coupon.dto.enums.CouponResponse;
+import com.idukbaduk.itseats.coupon.service.CouponService;
+import com.idukbaduk.itseats.global.response.BaseResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("api/coupons")
+public class CouponController {
+
+    private final CouponService couponService;
+
+    @GetMapping
+    public ResponseEntity<BaseResponse> getMyCoupons(
+            @AuthenticationPrincipal UserDetails userDetails
+    ) {
+        MyCouponListResponse response = couponService.getMyCoupons(userDetails.getUsername());
+        return BaseResponse.toResponseEntity(CouponResponse.GET_MY_COUPONS, response);
+    }
+}

--- a/src/main/java/com/idukbaduk/itseats/coupon/dto/MyCouponDto.java
+++ b/src/main/java/com/idukbaduk/itseats/coupon/dto/MyCouponDto.java
@@ -1,0 +1,18 @@
+package com.idukbaduk.itseats.coupon.dto;
+
+import com.idukbaduk.itseats.coupon.entity.enums.CouponType;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class MyCouponDto {
+    private CouponType couponType;
+    private int minPrice;
+    private int discountValue;
+    private LocalDateTime issueDate;
+    private LocalDateTime validDate;
+    private boolean canUsed;
+}

--- a/src/main/java/com/idukbaduk/itseats/coupon/dto/MyCouponListResponse.java
+++ b/src/main/java/com/idukbaduk/itseats/coupon/dto/MyCouponListResponse.java
@@ -1,0 +1,14 @@
+package com.idukbaduk.itseats.coupon.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class MyCouponListResponse {
+    private List<MyCouponDto> myCouponDtos;
+}

--- a/src/main/java/com/idukbaduk/itseats/coupon/dto/enums/CouponResponse.java
+++ b/src/main/java/com/idukbaduk/itseats/coupon/dto/enums/CouponResponse.java
@@ -1,0 +1,25 @@
+package com.idukbaduk.itseats.coupon.dto.enums;
+
+import com.idukbaduk.itseats.global.response.Response;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@RequiredArgsConstructor
+public enum CouponResponse implements Response {
+
+    GET_MY_COUPONS(HttpStatus.OK, "내 쿠폰 조회 성공"),
+    ;
+
+    private final HttpStatus httpStatus;
+    private final String message;
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return httpStatus;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+}

--- a/src/main/java/com/idukbaduk/itseats/coupon/repository/MemberCouponRepository.java
+++ b/src/main/java/com/idukbaduk/itseats/coupon/repository/MemberCouponRepository.java
@@ -1,0 +1,11 @@
+package com.idukbaduk.itseats.coupon.repository;
+
+import com.idukbaduk.itseats.coupon.entity.MemberCoupon;
+import com.idukbaduk.itseats.member.entity.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface MemberCouponRepository extends JpaRepository<MemberCoupon, Long> {
+    List<MemberCoupon> findAllByMember(Member member);
+}

--- a/src/main/java/com/idukbaduk/itseats/coupon/service/CouponService.java
+++ b/src/main/java/com/idukbaduk/itseats/coupon/service/CouponService.java
@@ -1,0 +1,45 @@
+package com.idukbaduk.itseats.coupon.service;
+
+import com.idukbaduk.itseats.coupon.dto.MyCouponDto;
+import com.idukbaduk.itseats.coupon.dto.MyCouponListResponse;
+import com.idukbaduk.itseats.coupon.entity.MemberCoupon;
+import com.idukbaduk.itseats.coupon.repository.MemberCouponRepository;
+import com.idukbaduk.itseats.member.entity.Member;
+import com.idukbaduk.itseats.member.error.MemberException;
+import com.idukbaduk.itseats.member.error.enums.MemberErrorCode;
+import com.idukbaduk.itseats.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class CouponService {
+
+    private final MemberRepository memberRepository;
+    private final MemberCouponRepository memberCouponRepository;
+
+    public MyCouponListResponse getMyCoupons(String username) {
+        Member member = memberRepository.findByUsername(username)
+                .orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
+
+        List<MemberCoupon> myCoupons = memberCouponRepository.findAllByMember(member);
+
+        LocalDateTime now = LocalDateTime.now();
+
+        List<MyCouponDto> couponDtos = myCoupons.stream()
+                .map(mc -> MyCouponDto.builder()
+                        .couponType(mc.getCoupon().getCouponType())
+                        .minPrice(mc.getCoupon().getMinPrice())
+                        .discountValue(mc.getCoupon().getDiscountValue())
+                        .issueDate(mc.getIssueDate())
+                        .validDate(mc.getValidDate())
+                        .canUsed(!mc.getIsUsed() && now.isBefore(mc.getValidDate()) && now.isAfter(mc.getIssueDate()))
+                        .build())
+                .toList();
+
+        return MyCouponListResponse.builder().myCouponDtos(couponDtos).build();
+    }
+}

--- a/src/main/java/com/idukbaduk/itseats/coupon/service/CouponService.java
+++ b/src/main/java/com/idukbaduk/itseats/coupon/service/CouponService.java
@@ -10,6 +10,7 @@ import com.idukbaduk.itseats.member.error.enums.MemberErrorCode;
 import com.idukbaduk.itseats.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -21,6 +22,7 @@ public class CouponService {
     private final MemberRepository memberRepository;
     private final MemberCouponRepository memberCouponRepository;
 
+    @Transactional(readOnly = true)
     public MyCouponListResponse getMyCoupons(String username) {
         Member member = memberRepository.findByUsername(username)
                 .orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));

--- a/src/main/java/com/idukbaduk/itseats/coupon/service/CouponService.java
+++ b/src/main/java/com/idukbaduk/itseats/coupon/service/CouponService.java
@@ -29,8 +29,6 @@ public class CouponService {
 
         List<MemberCoupon> myCoupons = memberCouponRepository.findAllByMember(member);
 
-        LocalDateTime now = LocalDateTime.now();
-
         List<MyCouponDto> couponDtos = myCoupons.stream()
                 .map(mc -> MyCouponDto.builder()
                         .couponType(mc.getCoupon().getCouponType())
@@ -38,10 +36,16 @@ public class CouponService {
                         .discountValue(mc.getCoupon().getDiscountValue())
                         .issueDate(mc.getIssueDate())
                         .validDate(mc.getValidDate())
-                        .canUsed(!mc.getIsUsed() && now.isBefore(mc.getValidDate()) && now.isAfter(mc.getIssueDate()))
+                        .canUsed(canUse(mc))
                         .build())
                 .toList();
 
         return MyCouponListResponse.builder().myCouponDtos(couponDtos).build();
+    }
+
+    private boolean canUse(MemberCoupon memberCoupon) {
+        return !memberCoupon.getIsUsed()
+                && LocalDateTime.now().isBefore(memberCoupon.getValidDate())
+                && LocalDateTime.now().isAfter(memberCoupon.getIssueDate());
     }
 }

--- a/src/test/java/com/idukbaduk/itseats/coupon/controller/CouponControllerTest.java
+++ b/src/test/java/com/idukbaduk/itseats/coupon/controller/CouponControllerTest.java
@@ -1,0 +1,61 @@
+package com.idukbaduk.itseats.coupon.controller;
+
+import com.idukbaduk.itseats.coupon.dto.MyCouponDto;
+import com.idukbaduk.itseats.coupon.dto.MyCouponListResponse;
+import com.idukbaduk.itseats.coupon.dto.enums.CouponResponse;
+import com.idukbaduk.itseats.coupon.service.CouponService;
+import com.idukbaduk.itseats.global.response.BaseResponse;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(CouponController.class)
+class CouponControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private CouponService couponService;
+
+    @Test
+    @DisplayName("내 쿠폰 목록 조회 API 성공")
+    @WithMockUser(username = "testuser")
+    void getMyCoupons_success() throws Exception {
+        // given
+        MyCouponDto dto = MyCouponDto.builder()
+                .couponType(com.idukbaduk.itseats.coupon.entity.enums.CouponType.FIXED)
+                .minPrice(10000)
+                .discountValue(1000)
+                .issueDate(LocalDateTime.now())
+                .validDate(LocalDateTime.now().plusDays(1))
+                .canUsed(true)
+                .build();
+        MyCouponListResponse listResponse = MyCouponListResponse.builder()
+                .myCouponDtos(List.of(dto))
+                .build();
+
+        when(couponService.getMyCoupons(anyString())).thenReturn(listResponse);
+
+        // when & then
+        mockMvc.perform(get("/api/coupons")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.myCouponDtos[0].couponType").value("FIXED"))
+                .andExpect(jsonPath("$.data.myCouponDtos[0].canUsed").value(true));
+    }
+}

--- a/src/test/java/com/idukbaduk/itseats/coupon/service/CouponServiceTest.java
+++ b/src/test/java/com/idukbaduk/itseats/coupon/service/CouponServiceTest.java
@@ -1,0 +1,96 @@
+package com.idukbaduk.itseats.coupon.service;
+
+import com.idukbaduk.itseats.coupon.dto.MyCouponDto;
+import com.idukbaduk.itseats.coupon.dto.MyCouponListResponse;
+import com.idukbaduk.itseats.coupon.entity.Coupon;
+import com.idukbaduk.itseats.coupon.entity.MemberCoupon;
+import com.idukbaduk.itseats.coupon.entity.enums.CouponType;
+import com.idukbaduk.itseats.coupon.repository.MemberCouponRepository;
+import com.idukbaduk.itseats.member.entity.Member;
+import com.idukbaduk.itseats.member.error.MemberException;
+import com.idukbaduk.itseats.member.error.enums.MemberErrorCode;
+import com.idukbaduk.itseats.member.repository.MemberRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class CouponServiceTest {
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @Mock
+    private MemberCouponRepository memberCouponRepository;
+
+    @InjectMocks
+    private CouponService couponService;
+
+    @Test
+    @DisplayName("내 쿠폰 목록 정상 조회")
+    void getMyCoupons_success() {
+        Member member = Member.builder()
+                .memberId(1L)
+                .username("testuser")
+                .build();
+
+        Coupon coupon1 = Coupon.builder()
+                .couponType(CouponType.FIXED)
+                .minPrice(10000)
+                .discountValue(1000)
+                .build();
+        Coupon coupon2 = Coupon.builder()
+                .couponType(CouponType.RATE)
+                .minPrice(20000)
+                .discountValue(10)
+                .build();
+
+        LocalDateTime now = LocalDateTime.now();
+        MemberCoupon mc1 = MemberCoupon.builder()
+                .coupon(coupon1)
+                .isUsed(false)
+                .issueDate(now.minusDays(1))
+                .validDate(now.plusDays(2))
+                .build();
+        MemberCoupon mc2 = MemberCoupon.builder()
+                .coupon(coupon2)
+                .isUsed(true)
+                .issueDate(now.minusDays(2))
+                .validDate(now.plusDays(1))
+                .build();
+
+        when(memberRepository.findByUsername("testuser")).thenReturn(Optional.of(member));
+        when(memberCouponRepository.findAllByMember(member)).thenReturn(List.of(mc1, mc2));
+
+        MyCouponListResponse response = couponService.getMyCoupons("testuser");
+
+        assertThat(response.getMyCouponDtos()).hasSize(2);
+        MyCouponDto dto1 = response.getMyCouponDtos().get(0);
+        MyCouponDto dto2 = response.getMyCouponDtos().get(1);
+
+        assertThat(dto1.getCouponType()).isEqualTo(CouponType.FIXED);
+        assertThat(dto1.isCanUsed()).isTrue();
+        assertThat(dto2.getCouponType()).isEqualTo(CouponType.RATE);
+        assertThat(dto2.isCanUsed()).isFalse();
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 회원 예외 발생")
+    void getMyCoupons_memberNotFound() {
+        when(memberRepository.findByUsername("notfound")).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> couponService.getMyCoupons("notfound"))
+                .isInstanceOf(MemberException.class)
+                .hasMessageContaining(MemberErrorCode.MEMBER_NOT_FOUND.getMessage());
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

#206 
closes #206 
## 📝작업 내용
- [ ] Dto - `MyCouponDto`, `MyCouponListResponse` 작성
- [ ] `CouponService`, `CouponController`에 내 쿠폰목록 조회 관련 메서드 작성
- [ ] 테스트 코드 작성후 작동 확인 완료

### 스크린샷 (선택)
<img width="461" alt="image" src="https://github.com/user-attachments/assets/f1b782f9-5303-49f8-97e3-c2f99e0f3afe" />
<img width="462" alt="image" src="https://github.com/user-attachments/assets/635600ef-eb75-47f1-a368-0d5612b3f749" />

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 사용자가 본인의 쿠폰 목록을 조회할 수 있는 API가 추가되었습니다.

* **테스트**
  * 쿠폰 조회 컨트롤러와 서비스에 대한 단위 테스트가 추가되었습니다.  
  * 정상 조회 및 회원 미존재 시 예외 처리 테스트가 포함되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->