### PR TITLE
[Fix] 포스 홈화면 대시보드 조회 오류 수정

### DIFF
--- a/src/main/java/com/idukbaduk/itseats/store/service/OwnerStoreService.java
+++ b/src/main/java/com/idukbaduk/itseats/store/service/OwnerStoreService.java
@@ -19,6 +19,7 @@ import com.idukbaduk.itseats.store.repository.FranchiseRepository;
 import com.idukbaduk.itseats.store.repository.StoreCategoryRepository;
 import com.idukbaduk.itseats.store.repository.StoreImageRepository;
 import com.idukbaduk.itseats.store.repository.StoreRepository;
+import jakarta.annotation.Nullable;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -27,6 +28,7 @@ import org.springframework.web.multipart.MultipartFile;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -50,9 +52,11 @@ public class OwnerStoreService {
         Double avgRating = reviewRepository.findAverageRatingByStoreId(storeId);
         double customerRating = avgRating != null ? avgRating : 0.0;
 
-        Double avgCookTime = orderRepository.findAverageCookTimeByStoreId(storeId);
+        Double avgCookTime = Optional.ofNullable(orderRepository.findAverageCookTimeByStoreId(storeId))
+                .orElse(0.0);
         Long accurateCount = orderRepository.countAccurateOrdersByStoreId(storeId);
-        Double avgPickupTime = orderRepository.findAveragePickupTimeByStoreId(storeId);
+        Double avgPickupTime = Optional.ofNullable(orderRepository.findAveragePickupTimeByStoreId(storeId))
+                .orElse(0.0);
         Long totalOrders = orderRepository.countTotalOrdersByStoreId(storeId);
         Long acceptedOrders = orderRepository.countAcceptedOrdersByStoreId(storeId);
 


### PR DESCRIPTION
## #️⃣연관된 이슈

#214
closes #214

## 📝작업 내용

평균값 조회시 null로 인한 오류 수정



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 대시보드에서 평균 조리 시간과 평균 픽업 시간이 값이 없을 때 0.0으로 안전하게 표시되도록 개선되었습니다. Null 값으로 인한 오류 발생이 방지됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->