### PR TITLE
[Feature] 쿠폰 관련 테스트 코드 수정

### DIFF
--- a/src/main/java/com/idukbaduk/itseats/coupon/dto/enums/CouponResponse.java
+++ b/src/main/java/com/idukbaduk/itseats/coupon/dto/enums/CouponResponse.java
@@ -7,7 +7,7 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum CouponResponse implements Response {
 
-    ISSUE_COUPON_SUCCESS(HttpStatus.CREATED, "쿠폰이 발급되었습니다.")
+    ISSUE_COUPON_SUCCESS(HttpStatus.CREATED, "쿠폰이 발급되었습니다."),
     CREATE_COUPON_SUCCESS(HttpStatus.CREATED, "쿠폰을 생성했습니다.")
     ;
 

--- a/src/main/java/com/idukbaduk/itseats/coupon/entity/Coupon.java
+++ b/src/main/java/com/idukbaduk/itseats/coupon/entity/Coupon.java
@@ -64,9 +64,6 @@ public class Coupon extends BaseEntity {
     @Column(name = "issue_end_date", nullable = false)
     private LocalDateTime issueEndDate;  // 발급 종료 일시
 
-    @Column(name = "issue_end_date", nullable = false)
-    private LocalDateTime issueEndDate;  // 발급 종료 일시
-
     @Column(name = "valid_date", nullable = false)
     private LocalDateTime validDate;  // 쿠폰 유효 기간
 

--- a/src/main/java/com/idukbaduk/itseats/coupon/service/CouponPolicyService.java
+++ b/src/main/java/com/idukbaduk/itseats/coupon/service/CouponPolicyService.java
@@ -12,7 +12,13 @@ import java.time.LocalDateTime;
 
 @Service
 public class CouponPolicyService {
-    public void validateCoupon(MemberCoupon memberCoupon, Member member, int orderPrice) {
+
+    public int applyCouponDiscount(MemberCoupon memberCoupon, Member member, int orderPrice) {
+        validateCoupon(memberCoupon, member, orderPrice);
+        return calculateDiscount(memberCoupon.getCoupon(), orderPrice);
+    }
+
+    private void validateCoupon(MemberCoupon memberCoupon, Member member, int orderPrice) {
         if (memberCoupon == null || !memberCoupon.getMember().equals(member)) {
             throw new CouponException(CouponErrorCode.COUPON_NOT_FOUND);
         }
@@ -27,14 +33,14 @@ public class CouponPolicyService {
         }
     }
 
-    public int calculateDiscount(Coupon coupon, int orderPrice) {
+    private int calculateDiscount(Coupon coupon, int orderPrice) {
         if (coupon.getCouponType() == CouponType.FIXED) {
             return Math.min(coupon.getDiscountValue(), orderPrice);
         }
         if (coupon.getCouponType() == CouponType.RATE) {
-            int discount = (int) Math.round(orderPrice * coupon.getDiscountValue() / 100.0);
+            int discount = orderPrice * coupon.getDiscountValue() / 100;
             return Math.min(discount, orderPrice);
         }
-        return 0;
+        throw new CouponException(CouponErrorCode.COUPON_NOT_FOUND);
     }
 }

--- a/src/main/java/com/idukbaduk/itseats/order/service/OrderService.java
+++ b/src/main/java/com/idukbaduk/itseats/order/service/OrderService.java
@@ -91,8 +91,7 @@ public class OrderService {
             MemberCoupon memberCoupon = memberCouponRepository.findById(orderNewRequest.getMemberCouponId())
                     .orElseThrow(() -> new CouponException(CouponErrorCode.COUPON_NOT_FOUND));
 
-            couponPolicyService.validateCoupon(memberCoupon, member, orderPrice);
-            discountValue = couponPolicyService.calculateDiscount(memberCoupon.getCoupon(), orderPrice);
+            discountValue = couponPolicyService.applyCouponDiscount(memberCoupon, member, orderPrice);
         }
 
         int totalCost = orderPrice - discountValue + deliveryFee;

--- a/src/test/java/com/idukbaduk/itseats/order/service/OrderServiceTest.java
+++ b/src/test/java/com/idukbaduk/itseats/order/service/OrderServiceTest.java
@@ -227,7 +227,7 @@ class OrderServiceTest {
 
         when(memberRepository.findByUsername(username)).thenReturn(Optional.ofNullable(member));
         when(memberAddressRepository.findByMemberAndAddressId(member, 1L)).thenReturn(Optional.ofNullable(address));
-        when(storeRepository.findByMemberAndStoreId(member, 1L)).thenReturn(Optional.ofNullable(store));
+        when(storeRepository.findByStoreId(1L)).thenReturn(Optional.ofNullable(store));
         when(memberCouponRepository.findById(couponId)).thenReturn(Optional.of(memberCoupon));
         when(menuRepository.findById(1L)).thenReturn(Optional.of(new Menu()));
         when(menuRepository.findById(2L)).thenReturn(Optional.of(new Menu()));
@@ -263,7 +263,7 @@ class OrderServiceTest {
         Long couponId = 100L;
         when(memberRepository.findByUsername(username)).thenReturn(Optional.ofNullable(member));
         when(memberAddressRepository.findByMemberAndAddressId(member, 1L)).thenReturn(Optional.ofNullable(address));
-        when(storeRepository.findByMemberAndStoreId(member, 1L)).thenReturn(Optional.ofNullable(store));
+        when(storeRepository.findByStoreId(1L)).thenReturn(Optional.ofNullable(store));
         when(memberCouponRepository.findById(couponId)).thenReturn(Optional.empty());
         when(menuRepository.findById(1L)).thenReturn(Optional.of(Menu.builder().build()));
         when(menuRepository.findById(2L)).thenReturn(Optional.of(Menu.builder().build()));
@@ -303,7 +303,7 @@ class OrderServiceTest {
 
         when(memberRepository.findByUsername(username)).thenReturn(Optional.ofNullable(member));
         when(memberAddressRepository.findByMemberAndAddressId(member, 1L)).thenReturn(Optional.ofNullable(address));
-        when(storeRepository.findByMemberAndStoreId(member, 1L)).thenReturn(Optional.ofNullable(store));
+        when(storeRepository.findByStoreId(1L)).thenReturn(Optional.ofNullable(store));
         when(memberCouponRepository.findById(couponId)).thenReturn(Optional.of(memberCoupon));
         when(menuRepository.findById(1L)).thenReturn(Optional.of(Menu.builder().build()));
         when(menuRepository.findById(2L)).thenReturn(Optional.of(Menu.builder().build()));
@@ -346,7 +346,7 @@ class OrderServiceTest {
 
         when(memberRepository.findByUsername(username)).thenReturn(Optional.ofNullable(member));
         when(memberAddressRepository.findByMemberAndAddressId(member, 1L)).thenReturn(Optional.ofNullable(address));
-        when(storeRepository.findByMemberAndStoreId(member, 1L)).thenReturn(Optional.ofNullable(store));
+        when(storeRepository.findByStoreId(1L)).thenReturn(Optional.ofNullable(store));
         when(memberCouponRepository.findById(couponId)).thenReturn(Optional.of(memberCoupon));
         when(menuRepository.findById(1L)).thenReturn(Optional.of(Menu.builder().build()));
         when(menuRepository.findById(2L)).thenReturn(Optional.of(Menu.builder().build()));

--- a/src/test/java/com/idukbaduk/itseats/order/service/OrderServiceTest.java
+++ b/src/test/java/com/idukbaduk/itseats/order/service/OrderServiceTest.java
@@ -236,9 +236,8 @@ class OrderServiceTest {
         when(orderRepository.findMinDeliveryTimeByType(DeliveryType.ONLY_ONE.name())).thenReturn(25);
         when(orderRepository.findMaxDeliveryTimeByType(DeliveryType.ONLY_ONE.name())).thenReturn(45);
         when(orderRepository.save(any(Order.class))).thenAnswer(i -> i.getArgument(0));
+        when(couponPolicyService.applyCouponDiscount(memberCoupon, member, 7000)).thenReturn(2000);
 
-        doNothing().when(couponPolicyService).validateCoupon(memberCoupon, member, 7000);
-        when(couponPolicyService.calculateDiscount(coupon, 7000)).thenReturn(2000);
 
         orderNewRequest = OrderNewRequest.builder()
                 .addrId(1L)
@@ -309,7 +308,7 @@ class OrderServiceTest {
         when(menuRepository.findById(2L)).thenReturn(Optional.of(Menu.builder().build()));
 
         doThrow(new CouponException(CouponErrorCode.COUPON_ALREADY_USED))
-                .when(couponPolicyService).validateCoupon(memberCoupon, member, 7000);
+                .when(couponPolicyService).applyCouponDiscount(memberCoupon, member, 7000);
 
         orderNewRequest = OrderNewRequest.builder()
                 .addrId(1L)
@@ -352,7 +351,7 @@ class OrderServiceTest {
         when(menuRepository.findById(2L)).thenReturn(Optional.of(Menu.builder().build()));
 
         doThrow(new CouponException(CouponErrorCode.COUPON_EXPIRED))
-                .when(couponPolicyService).validateCoupon(memberCoupon, member, 7000);
+                .when(couponPolicyService).applyCouponDiscount(memberCoupon, member, 7000);
 
         orderNewRequest = OrderNewRequest.builder()
                 .addrId(1L)


### PR DESCRIPTION
## #️⃣연관된 이슈

#221 
closes #221 

## 📝작업 내용
- `OrderServiceTest` 오류 해결
- `CouponResponse` 누락된 쉼표 추가
- `Coupon` 엔티티 중복 필드 제거
- `CouponPolicyService` 리팩토링
### 스크린샷 (선택)
<img width="456" alt="image" src="https://github.com/user-attachments/assets/454a705c-5b40-45e8-9e78-137d966ab704" />

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **버그 수정**
  * 쿠폰 관련 enum 상수 구분 오류를 수정했습니다.
  * 쿠폰 엔티티에서 중복된 필드 선언을 제거했습니다.

* **테스트**
  * 주문 서비스 테스트에서 저장소 메서드 호출 방식을 수정했습니다.

* **기능 개선**
  * 쿠폰 할인 적용 로직이 단일 메서드 호출로 통합되어 간소화되었습니다.
  * 쿠폰 할인 계산 방식이 일부 변경되어 정수 나눗셈으로 처리됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->