### PR TITLE
[Refactor] 메뉴 목록 조회시 응답 이미지 추가

### DIFF
--- a/src/main/java/com/idukbaduk/itseats/menu/dto/MenuInfoDto.java
+++ b/src/main/java/com/idukbaduk/itseats/menu/dto/MenuInfoDto.java
@@ -1,9 +1,13 @@
 package com.idukbaduk.itseats.menu.dto;
 
+import com.idukbaduk.itseats.menu.entity.Menu;
+import com.idukbaduk.itseats.menu.entity.MenuImage;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.util.List;
 
 @Getter
 @Builder
@@ -16,4 +20,17 @@ public class MenuInfoDto {
     private String menuStatus;
     private String menuGroupName;
     private int menuPriority;
+    private List<String> images;
+
+    public static MenuInfoDto of(Menu menu, List<MenuImage> images) {
+        return MenuInfoDto.builder()
+                .menuId(menu.getMenuId())
+                .menuName(menu.getMenuName())
+                .menuPrice(String.valueOf(menu.getMenuPrice()))
+                .menuStatus(menu.getMenuStatus().name())
+                .menuGroupName(menu.getMenuGroup().getMenuGroupName())
+                .menuPriority(menu.getMenuPriority())
+                .images(images.stream().map(MenuImage::getImageUrl).toList())
+                .build();
+    }
 }

--- a/src/main/java/com/idukbaduk/itseats/menu/service/MenuService.java
+++ b/src/main/java/com/idukbaduk/itseats/menu/service/MenuService.java
@@ -15,6 +15,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.*;
+import java.util.stream.Collectors;
 
 @Slf4j
 @Service
@@ -144,11 +145,13 @@ public class MenuService {
     }
 
     private MenuListResponse toMenuListResponse(List<Menu> menus, int totalMenuCount, int orderableMenuCount, int outOfStockTodayCount, int hiddenMenuCount) {
+        List<Long> menuIds = menus.stream().map(Menu::getMenuId).toList();
+        Map<Long, List<MenuImage>> menuImagesMap = menuImageRepository.findByMenu_MenuIdInOrderByMenu_MenuIdAscDisplayOrderAsc(menuIds)
+                .stream()
+                .collect(Collectors.groupingBy(image -> image.getMenu().getMenuId()));
+
         List<MenuInfoDto> menuInfos = menus.stream()
-                .map(m -> MenuInfoDto.of(
-                        m,
-                        menuImageRepository.findByMenu_MenuIdOrderByDisplayOrderAsc(m.getMenuId()
-                )))
+                .map(m -> MenuInfoDto.of(m, menuImagesMap.getOrDefault(m.getMenuId(), Collections.emptyList())))
                 .toList();
 
         return MenuListResponse.builder()

--- a/src/main/java/com/idukbaduk/itseats/menu/service/MenuService.java
+++ b/src/main/java/com/idukbaduk/itseats/menu/service/MenuService.java
@@ -6,6 +6,7 @@ import com.idukbaduk.itseats.menu.entity.enums.MenuStatus;
 import com.idukbaduk.itseats.menu.error.MenuErrorCode;
 import com.idukbaduk.itseats.menu.error.MenuException;
 import com.idukbaduk.itseats.menu.repository.MenuGroupRepository;
+import com.idukbaduk.itseats.menu.repository.MenuImageRepository;
 import com.idukbaduk.itseats.menu.repository.MenuRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -23,6 +24,7 @@ public class MenuService {
 
     private final MenuRepository menuRepository;
     private final MenuGroupRepository menuGroupRepository;
+    private final MenuImageRepository menuImageRepository;
     private final MenuMediaService menuMediaService;
 
     public MenuListResponse getMenuList(Long storeId, MenuListRequest request) {
@@ -143,14 +145,10 @@ public class MenuService {
 
     private MenuListResponse toMenuListResponse(List<Menu> menus, int totalMenuCount, int orderableMenuCount, int outOfStockTodayCount, int hiddenMenuCount) {
         List<MenuInfoDto> menuInfos = menus.stream()
-                .map(menu -> MenuInfoDto.builder()
-                        .menuId(menu.getMenuId())
-                        .menuName(menu.getMenuName())
-                        .menuPrice(String.valueOf(menu.getMenuPrice()))
-                        .menuStatus(menu.getMenuStatus().name())
-                        .menuGroupName(menu.getMenuGroup().getMenuGroupName())
-                        .menuPriority(menu.getMenuPriority())
-                        .build())
+                .map(m -> MenuInfoDto.of(
+                        m,
+                        menuImageRepository.findByMenu_MenuIdOrderByDisplayOrderAsc(m.getMenuId()
+                )))
                 .toList();
 
         return MenuListResponse.builder()

--- a/src/test/java/com/idukbaduk/itseats/menu/service/MenuServiceTest.java
+++ b/src/test/java/com/idukbaduk/itseats/menu/service/MenuServiceTest.java
@@ -31,6 +31,8 @@ class MenuServiceTest {
     @Mock
     private MenuGroupRepository menuGroupRepository;
     @Mock
+    private MenuImageRepository menuImageRepository;
+    @Mock
     private MenuMediaService menuMediaService;
 
     @InjectMocks

--- a/src/test/java/com/idukbaduk/itseats/menu/service/MenuServiceTest.java
+++ b/src/test/java/com/idukbaduk/itseats/menu/service/MenuServiceTest.java
@@ -92,6 +92,8 @@ class MenuServiceTest {
 
         when(menuRepository.findMenusByStore(storeId, "음료", "라떼"))
                 .thenReturn(mockMenus);
+        when(menuImageRepository.findByMenu_MenuIdInOrderByMenu_MenuIdAscDisplayOrderAsc(any()))
+                .thenReturn(Collections.emptyList());
 
         // when
         MenuListResponse response = menuService.getMenuList(storeId, request);
@@ -449,6 +451,8 @@ class MenuServiceTest {
                 Menu.builder().menuId(2L).menuPriority(2).menuStatus(MenuStatus.ON_SALE).menuGroup(menuGroup).build()
         ));
         when(menuRepository.findByStoreId(storeId)).thenReturn(menus);
+        when(menuImageRepository.findByMenu_MenuIdInOrderByMenu_MenuIdAscDisplayOrderAsc(any()))
+                .thenReturn(Collections.emptyList());
 
         List<MenuInfoDto> menuInfoDtos = List.of(
                 MenuInfoDto.builder().menuId(1L).menuPriority(2).build(),


### PR DESCRIPTION
## #️⃣연관된 이슈

#232
closes #232

## 📝작업 내용

메뉴 목록 조회시 응답 이미지 추가

가맹점 메뉴 목록 조회 API 연동 중 발생한 변경사항입니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 메뉴 정보에 이미지 URL 목록이 추가되어, 각 메뉴에 여러 이미지를 표시할 수 있습니다.

* **테스트**
  * 메뉴 이미지 관련 기능을 위한 테스트용 모의 객체가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->