### PR TITLE
[Fix] 메뉴 상세 조회시 MultipleBagFetchException 오류 수정

### DIFF
--- a/src/main/java/com/idukbaduk/itseats/menu/repository/MenuRepository.java
+++ b/src/main/java/com/idukbaduk/itseats/menu/repository/MenuRepository.java
@@ -41,7 +41,6 @@ public interface MenuRepository extends JpaRepository<Menu, Long> {
     @Query("SELECT m FROM Menu m " +
             "JOIN FETCH m.menuGroup mg " +
             "LEFT JOIN FETCH m.menuOptionGroups mog " +
-            "LEFT JOIN FETCH mog.options o " +
             "WHERE m.menuId = :menuId AND m.deleted = false ")
     Optional<Menu> findDetailById(@Param("menuId") Long menuId);
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

#234

## 📝작업 내용

JPA/Hibernate에서 **MultipleBagFetchException**이라는 고질적인 문제로, 두 개 이상의 @OneToMany(bag) 관계를 fetch join으로 동시에 로딩하려 할 때 발생합니다.

오류 발생 지점
```
    @Query("SELECT m FROM Menu m " +
            "JOIN FETCH m.menuGroup mg " +
            "LEFT JOIN FETCH m.menuOptionGroups mog " +
            "LEFT JOIN FETCH mog.options o " +
            "WHERE m.menuId = :menuId AND m.deleted = false ")
    Optional<Menu> findDetailById(@Param("menuId") Long menuId);
```

```
org.hibernate.loader.MultipleBagFetchException: 
cannot simultaneously fetch multiple bags: 
[MenuOptionGroup.options, Menu.menuOptionGroups]
```

Menu.menuOptionGroups: `@OneToMany`
MenuOptionGroup.options: `@OneToMany`

이처럼 List 타입으로 매핑된 컬렉션을 동시에 Fetch Join하면 Hibernate가 내부적으로 Cartesian product를 만들 수 없어 에러를 발생시킵니다.


### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

JOIN FETCH를 두 번 중첩해서 조회할 때 발생하는 오류 수정입니다!