### PR TITLE
[Refactor] 주문 및 결제 API 수정

### DIFF
--- a/src/main/java/com/idukbaduk/itseats/order/controller/OrderController.java
+++ b/src/main/java/com/idukbaduk/itseats/order/controller/OrderController.java
@@ -32,6 +32,16 @@ public class OrderController {
         );
     }
 
+    @PostMapping("/new")
+    public ResponseEntity<BaseResponse> createOrder(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @RequestBody OrderCreateRequest orderCreateRequest) {
+        return BaseResponse.toResponseEntity(
+                OrderResponse.CREATE_ORDER_SUCCESS,
+                orderService.createOrder(userDetails.getUsername(), orderCreateRequest)
+        );
+    }
+
     @GetMapping
     public ResponseEntity<BaseResponse> getOrders(
             @AuthenticationPrincipal UserDetails userDetails,

--- a/src/main/java/com/idukbaduk/itseats/order/controller/OrderController.java
+++ b/src/main/java/com/idukbaduk/itseats/order/controller/OrderController.java
@@ -1,9 +1,10 @@
 package com.idukbaduk.itseats.order.controller;
 
 import com.idukbaduk.itseats.global.response.BaseResponse;
-import com.idukbaduk.itseats.order.dto.OrderNewRequest;
+import com.idukbaduk.itseats.order.dto.OrderCreateRequest;
 import com.idukbaduk.itseats.order.dto.enums.OrderResponse;
 import com.idukbaduk.itseats.order.service.OrderService;
+import jakarta.annotation.Nullable;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
@@ -19,13 +20,15 @@ public class OrderController {
 
     private final OrderService orderService;
 
-    @PostMapping("/new")
-    public ResponseEntity<BaseResponse> getOrderNew(
+    @GetMapping("/{storeId}/details")
+    public ResponseEntity<BaseResponse> getOrderDetails(
             @AuthenticationPrincipal UserDetails userDetails,
-            @RequestBody OrderNewRequest orderNewRequest) {
+            @PathVariable("storeId") Long storeId,
+            @RequestParam("coupon") @Nullable Long couponId,
+            @RequestParam("orderPrice") @Nullable Integer orderPrice) {
         return BaseResponse.toResponseEntity(
                 OrderResponse.GET_ORDER_DETAILS_SUCCESS,
-                orderService.getOrderNew(userDetails.getUsername(), orderNewRequest)
+                orderService.getOrderDetails(userDetails.getUsername(), storeId, couponId, orderPrice)
         );
     }
 

--- a/src/main/java/com/idukbaduk/itseats/order/controller/OwnerOrderController.java
+++ b/src/main/java/com/idukbaduk/itseats/order/controller/OwnerOrderController.java
@@ -24,7 +24,7 @@ public class OwnerOrderController {
     public ResponseEntity<BaseResponse> getOrderDetail(
             @AuthenticationPrincipal UserDetails userDetails,
             @PathVariable("orderId") Long orderId) {
-        OrderDetailResponse response = ownerOrderService.getOrderDetail(userDetails.getUsername(), orderId);
+        OwnerOrderDetailsResponse response = ownerOrderService.getOrderDetail(userDetails.getUsername(), orderId);
         return BaseResponse.toResponseEntity(OrderResponse.GET_ORDER_DETAILS_SUCCESS, response);
     }
 

--- a/src/main/java/com/idukbaduk/itseats/order/dto/OrderCreateRequest.java
+++ b/src/main/java/com/idukbaduk/itseats/order/dto/OrderCreateRequest.java
@@ -12,6 +12,5 @@ public class OrderCreateRequest {
     private Long addrId;
     private Long storeId;
     private List<OrderMenuDTO> orderMenus;
-    private Long memberCouponId;
     private String deliveryType;
 }

--- a/src/main/java/com/idukbaduk/itseats/order/dto/OrderCreateRequest.java
+++ b/src/main/java/com/idukbaduk/itseats/order/dto/OrderCreateRequest.java
@@ -7,7 +7,7 @@ import java.util.List;
 
 @Getter
 @Builder
-public class OrderNewRequest {
+public class OrderCreateRequest {
 
     private Long addrId;
     private Long storeId;

--- a/src/main/java/com/idukbaduk/itseats/order/dto/OrderCreateResponse.java
+++ b/src/main/java/com/idukbaduk/itseats/order/dto/OrderCreateResponse.java
@@ -5,15 +5,11 @@ import lombok.Getter;
 
 @Getter
 @Builder
-public class OrderNewResponse {
+public class OrderCreateResponse {
 
     private Long orderId;
-    private int defaultTimeMin;
-    private int defaultTimeMax;
-    private int onlyOneTimeMin;
-    private int onlyOneTimeMax;
     private int orderPrice;
-    private int deliveryFee;
     private int discountValue;
+    private int deliveryFee;
     private int totalCost;
 }

--- a/src/main/java/com/idukbaduk/itseats/order/dto/OrderCreateResponse.java
+++ b/src/main/java/com/idukbaduk/itseats/order/dto/OrderCreateResponse.java
@@ -8,8 +8,4 @@ import lombok.Getter;
 public class OrderCreateResponse {
 
     private Long orderId;
-    private int orderPrice;
-    private int discountValue;
-    private int deliveryFee;
-    private int totalCost;
 }

--- a/src/main/java/com/idukbaduk/itseats/order/dto/OrderDetailsResponse.java
+++ b/src/main/java/com/idukbaduk/itseats/order/dto/OrderDetailsResponse.java
@@ -3,20 +3,15 @@ package com.idukbaduk.itseats.order.dto;
 import lombok.Builder;
 import lombok.Getter;
 
-import java.util.List;
-
 @Getter
 @Builder
 public class OrderDetailsResponse {
 
-    private Long orderId;
-    private String orderNumber;
-    private String orderStatus;
-    private String orderTime;
-    private int totalPrice;
-    private List<OrderItemDTO> orderItems;
-    private String storePhone;
-    private String memberPhone;
-    private String storeRequest;
-    private String riderRequest;
+    private int defaultTimeMin;
+    private int defaultTimeMax;
+    private int onlyOneTimeMin;
+    private int onlyOneTimeMax;
+    private int defaultDeliveryFee;
+    private int onlyOneDeliveryFee;
+    private int discountValue;
 }

--- a/src/main/java/com/idukbaduk/itseats/order/dto/OwnerOrderDetailsResponse.java
+++ b/src/main/java/com/idukbaduk/itseats/order/dto/OwnerOrderDetailsResponse.java
@@ -7,7 +7,7 @@ import java.util.List;
 
 @Getter
 @Builder
-public class OrderDetailResponse {
+public class OwnerOrderDetailsResponse {
     private Long orderId;
     private String orderNumber;
     private String memberName;

--- a/src/main/java/com/idukbaduk/itseats/order/dto/RiderOrderDetailsResponse.java
+++ b/src/main/java/com/idukbaduk/itseats/order/dto/RiderOrderDetailsResponse.java
@@ -1,0 +1,22 @@
+package com.idukbaduk.itseats.order.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class RiderOrderDetailsResponse {
+
+    private Long orderId;
+    private String orderNumber;
+    private String orderStatus;
+    private String orderTime;
+    private int totalPrice;
+    private List<OrderItemDTO> orderItems;
+    private String storePhone;
+    private String memberPhone;
+    private String storeRequest;
+    private String riderRequest;
+}

--- a/src/main/java/com/idukbaduk/itseats/order/dto/enums/OrderResponse.java
+++ b/src/main/java/com/idukbaduk/itseats/order/dto/enums/OrderResponse.java
@@ -9,6 +9,7 @@ public enum OrderResponse implements Response {
 
     GET_ORDERS_SUCCESS(HttpStatus.OK, "과거 주문 내역 조회 성공"),
     GET_ORDER_DETAILS_SUCCESS(HttpStatus.OK, "주문 정보 상세 조회 성공"),
+    CREATE_ORDER_SUCCESS(HttpStatus.CREATED, "주문 정보 저장 성공"),
     GET_ORDER_STATUS_SUCCESS(HttpStatus.OK, "주문 현황 조회 성공"),
     GET_STORE_ORDERS_SUCCESS(HttpStatus.OK, "주문 접수 조회 성공"),
     REJECT_ORDER_SUCCESS(HttpStatus.OK, "주문 거절 완료"),

--- a/src/main/java/com/idukbaduk/itseats/order/entity/enums/OrderStatus.java
+++ b/src/main/java/com/idukbaduk/itseats/order/entity/enums/OrderStatus.java
@@ -13,8 +13,10 @@ public enum OrderStatus {
 
     // 주문 취소
     CANCELED(null),
+    // 주문 결제 전
+    PENDING(null),
     // 주문 접수 중
-    WAITING(null),
+    WAITING(PENDING),
     // 주문 수락
     ACCEPTED(WAITING),
     // 주문 거절

--- a/src/main/java/com/idukbaduk/itseats/order/service/OrderService.java
+++ b/src/main/java/com/idukbaduk/itseats/order/service/OrderService.java
@@ -110,6 +110,7 @@ public class OrderService {
                 .build();
     }
 
+    @Transactional
     public OrderCreateResponse createOrder(String username, OrderCreateRequest request) {
         Member member = memberRepository.findByUsername(username)
                 .orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));

--- a/src/main/java/com/idukbaduk/itseats/order/service/OwnerOrderService.java
+++ b/src/main/java/com/idukbaduk/itseats/order/service/OwnerOrderService.java
@@ -28,7 +28,7 @@ public class OwnerOrderService {
     private final PaymentRepository paymentRepository;
 
     @Transactional(readOnly = true)
-    public OrderDetailResponse getOrderDetail(String username, Long orderId) {
+    public OwnerOrderDetailsResponse getOrderDetail(String username, Long orderId) {
         Order order = orderRepository.findDetailByStoreUsernameAndId(username, orderId)
                 .orElseThrow(() -> new OrderException(OrderErrorCode.ORDER_NOT_FOUND));
 
@@ -46,7 +46,7 @@ public class OwnerOrderService {
                 .mapToInt(om -> om.getPrice() * om.getQuantity())
                 .sum();
 
-        return OrderDetailResponse.builder()
+        return OwnerOrderDetailsResponse.builder()
                 .orderId(order.getOrderId())
                 .orderNumber(order.getOrderNumber())
                 .memberName(order.getMember().getName())

--- a/src/main/java/com/idukbaduk/itseats/order/service/RiderOrderService.java
+++ b/src/main/java/com/idukbaduk/itseats/order/service/RiderOrderService.java
@@ -1,7 +1,7 @@
 package com.idukbaduk.itseats.order.service;
 
 import com.idukbaduk.itseats.order.dto.AddressInfoDTO;
-import com.idukbaduk.itseats.order.dto.OrderDetailsResponse;
+import com.idukbaduk.itseats.order.dto.RiderOrderDetailsResponse;
 import com.idukbaduk.itseats.order.dto.OrderItemDTO;
 import com.idukbaduk.itseats.order.dto.OrderRequestResponse;
 import com.idukbaduk.itseats.order.dto.RiderImageResponse;
@@ -42,7 +42,7 @@ public class RiderOrderService {
     private final RiderService riderService;
 
     @Transactional(readOnly = true)
-    public OrderDetailsResponse getOrderDetails(String username, Long orderId) {
+    public RiderOrderDetailsResponse getOrderDetails(String username, Long orderId) {
         Rider rider = riderRepository.findByUsername(username)
                 .orElseThrow(() -> new RiderException(RiderErrorCode.RIDER_NOT_FOUND));
         Order order = orderRepository.findByRiderAndOrderId(rider, orderId)
@@ -51,10 +51,10 @@ public class RiderOrderService {
         return buildOrderDetails(order);
     }
 
-    private OrderDetailsResponse buildOrderDetails(Order order) {
+    private RiderOrderDetailsResponse buildOrderDetails(Order order) {
         Payment payment = paymentRepository.findByOrder(order)
                 .orElseThrow(() -> new PaymentException(PaymentErrorCode.PAYMENT_NOT_FOUND));
-        return OrderDetailsResponse.builder()
+        return RiderOrderDetailsResponse.builder()
                 .orderId(order.getOrderId())
                 .orderNumber(order.getOrderNumber())
                 .orderStatus(order.getOrderStatus().name())

--- a/src/main/java/com/idukbaduk/itseats/payment/repository/PaymentRepository.java
+++ b/src/main/java/com/idukbaduk/itseats/payment/repository/PaymentRepository.java
@@ -17,6 +17,7 @@ public interface PaymentRepository extends JpaRepository<Payment, Long> {
     @Query("""
         SELECT p
         FROM Payment p
+        JOIN FETCH Order o
         WHERE p.member.username = :username
           AND p.paymentId = :paymentId
     """)

--- a/src/main/java/com/idukbaduk/itseats/payment/service/PaymentService.java
+++ b/src/main/java/com/idukbaduk/itseats/payment/service/PaymentService.java
@@ -12,6 +12,7 @@ import com.idukbaduk.itseats.member.error.MemberException;
 import com.idukbaduk.itseats.member.error.enums.MemberErrorCode;
 import com.idukbaduk.itseats.member.repository.MemberRepository;
 import com.idukbaduk.itseats.order.entity.Order;
+import com.idukbaduk.itseats.order.entity.enums.OrderStatus;
 import com.idukbaduk.itseats.order.error.OrderException;
 import com.idukbaduk.itseats.order.error.enums.OrderErrorCode;
 import com.idukbaduk.itseats.order.repository.OrderRepository;
@@ -105,6 +106,7 @@ public class PaymentService {
         validateAmount(payment.getTotalCost(), clientResponse.getTotalAmount());
 
         payment.confirm(clientResponse.getPaymentKey(), clientResponse.getOrderId());
+        payment.getOrder().updateStatus(OrderStatus.WAITING);
         paymentRepository.save(payment);
     }
 

--- a/src/test/java/com/idukbaduk/itseats/order/controller/OwnerOrderControllerTest.java
+++ b/src/test/java/com/idukbaduk/itseats/order/controller/OwnerOrderControllerTest.java
@@ -61,7 +61,7 @@ class OwnerOrderControllerTest {
                 .options(List.of())
                 .build();
 
-        OrderDetailResponse response = OrderDetailResponse.builder()
+        OwnerOrderDetailsResponse response = OwnerOrderDetailsResponse.builder()
                 .orderId(3L)
                 .orderNumber("GRMT0N")
                 .memberName("구름톤")

--- a/src/test/java/com/idukbaduk/itseats/order/controller/RiderOrderControllerTest.java
+++ b/src/test/java/com/idukbaduk/itseats/order/controller/RiderOrderControllerTest.java
@@ -1,7 +1,7 @@
 package com.idukbaduk.itseats.order.controller;
 
 import com.idukbaduk.itseats.order.dto.AddressInfoDTO;
-import com.idukbaduk.itseats.order.dto.OrderDetailsResponse;
+import com.idukbaduk.itseats.order.dto.RiderOrderDetailsResponse;
 import com.idukbaduk.itseats.order.dto.OrderRequestResponse;
 import com.idukbaduk.itseats.order.dto.RiderImageResponse;
 import com.idukbaduk.itseats.order.dto.enums.OrderResponse;
@@ -46,7 +46,7 @@ class RiderOrderControllerTest {
     void getOrderDetails_success() throws Exception {
         // given
         Long orderId = 1L;
-        OrderDetailsResponse response = OrderDetailsResponse.builder()
+        RiderOrderDetailsResponse response = RiderOrderDetailsResponse.builder()
                 .orderId(orderId)
                 .build();
 

--- a/src/test/java/com/idukbaduk/itseats/order/service/RiderOrderServiceTest.java
+++ b/src/test/java/com/idukbaduk/itseats/order/service/RiderOrderServiceTest.java
@@ -2,7 +2,7 @@ package com.idukbaduk.itseats.order.service;
 
 import com.idukbaduk.itseats.global.util.GeoUtil;
 import com.idukbaduk.itseats.member.entity.Member;
-import com.idukbaduk.itseats.order.dto.OrderDetailsResponse;
+import com.idukbaduk.itseats.order.dto.RiderOrderDetailsResponse;
 import com.idukbaduk.itseats.order.dto.OrderItemDTO;
 import com.idukbaduk.itseats.order.dto.OrderRequestResponse;
 import com.idukbaduk.itseats.order.dto.RiderImageResponse;
@@ -151,7 +151,7 @@ class RiderOrderServiceTest {
         when(paymentRepository.findByOrder(order)).thenReturn(Optional.of(payment));
 
         // when
-        OrderDetailsResponse response = riderOrderService.getOrderDetails(username, 1L);
+        RiderOrderDetailsResponse response = riderOrderService.getOrderDetails(username, 1L);
 
         // then
         assertThat(response.getOrderId()).isEqualTo(order.getOrderId());


### PR DESCRIPTION
## #️⃣연관된 이슈

#229
## 📝작업 내용

- 주문/결제 프로세스 중 필요한 API를 추가하고 기존 API를 수정하였습니다.

### 주문 상세 정보 조회 API

- `@GetMapping`으로 변경
- 엔드포인트 변경 : `/api/orders/{storeId}/details?coupon={couponId}&orderPrice={orderPrice}`
  - 사용하는 쿠폰이 있는 경우 RequestParam으로 couponId와 orderPrice를 넘겨줘야합니다.
  - 사용하는 쿠폰이 없는 경우 `/api/orders/{storeId}/details` 이렇게 사용하면 됩니다.
- RequestBody 삭제
- 응답 정보 변경
   - 주문 결제 페이지에 필요한 정보 (배달 최소/최대 시간, 배달팁, 할인금액) 을 전달합니다.

### 주문 정보 저장 API

- 기존 `주문 상세 정보 조회 API` (엔드포인트 `/api/orders/new`)와 동일
- 주문 정보를 저장할 때 결제 실패를 대비해 `PENDING` 상태 추가 후 이 상태로 저장하도록 했습니다.

### 결제 승인 API

- 결제 상태 뿐만 아니라 주문 상태도 변경하는 코드를 추가
> 이 부분은 프론트엔드와 연동 후 테스트 진행 예정입니다!

### 스크린샷

> 주문 상세 정보 조회
<img width="556" height="415" alt="image" src="https://github.com/user-attachments/assets/cc3313a6-2203-43e1-bcfb-6ae4ca546187" />

> 주문 정보 저장
<img width="474" height="305" alt="image" src="https://github.com/user-attachments/assets/1eae9926-5c9d-491d-ac72-9e9538c9c2b8" />

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 주문 생성 시 주문 ID를 반환하는 응답이 추가되었습니다.
  * 라이더용 주문 상세 정보 응답이 새롭게 제공됩니다.

* **기능 개선**
  * 주문 상세 조회와 주문 생성이 별도의 엔드포인트로 분리되었습니다.
  * 주문 상세 응답 구조가 배달 시간, 배달비, 할인 정보 중심으로 단순화되었습니다.
  * 주문 상태에 ‘결제 전(PENDING)’ 단계를 추가하고, 결제 완료 시 상태가 자동으로 ‘대기(WAITING)’로 변경됩니다.

* **버그 수정**
  * 쿠폰 검증 및 할인 적용 로직이 명확하게 동작하도록 개선되었습니다.

* **테스트**
  * 변경된 서비스 구조와 DTO에 맞춰 테스트 코드가 전면 수정 및 보강되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->