### PR TITLE
chore: CORS 설정 추가

### DIFF
--- a/src/main/java/com/idukbaduk/itseats/global/config/CorsConfig.java
+++ b/src/main/java/com/idukbaduk/itseats/global/config/CorsConfig.java
@@ -17,7 +17,11 @@ public class CorsConfig {
         config.setAllowedOriginPatterns(List.of(
                 "http://localhost:5173",
                 "http://itseats.shop",
-                "https://itseats.shop"
+                "https://itseats.shop",
+                "http://owner.itseats.shop",
+                "https://owner.itseats.shop",
+                "http://rider.itseats.shop",
+                "https://rider.itseats.shop"
         ));
         config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS"));
         config.setAllowedHeaders(List.of("*"));


### PR DESCRIPTION
## #️⃣연관된 이슈


## 📝작업 내용

CORS 설정에 가맹점용 프론트엔드와 라이더용 프론트엔드 도메인을 추가합니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * CORS 허용 도메인에 "owner.itseats.shop"과 "rider.itseats.shop"의 HTTP 및 HTTPS 주소가 추가되었습니다.  
  * 이제 더 다양한 서브도메인에서 서비스에 접근할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->