### PR TITLE
[Refactor] 라이더 회원가입 및 내 정보 조회 API 분리

### DIFF
--- a/src/main/java/com/idukbaduk/itseats/member/controller/RiderMemberController.java
+++ b/src/main/java/com/idukbaduk/itseats/member/controller/RiderMemberController.java
@@ -2,10 +2,10 @@ package com.idukbaduk.itseats.member.controller;
 
 import com.idukbaduk.itseats.global.response.BaseResponse;
 import com.idukbaduk.itseats.member.dto.enums.MemberResponse;
-import com.idukbaduk.itseats.member.dto.request.OwnerCreateRequest;
+import com.idukbaduk.itseats.member.dto.request.RiderCreateRequest;
 import com.idukbaduk.itseats.member.error.MemberException;
 import com.idukbaduk.itseats.member.error.enums.MemberErrorCode;
-import com.idukbaduk.itseats.member.service.OwnerMemberService;
+import com.idukbaduk.itseats.member.service.RiderMemberService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -17,16 +17,16 @@ import org.springframework.web.bind.annotation.*;
 @Slf4j
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/owner/members")
-public class OwnerMemberController {
+@RequestMapping("/api/rider/members")
+public class RiderMemberController {
 
-    private final OwnerMemberService ownerMemberService;
+    private final RiderMemberService riderMemberService;
 
     @PostMapping("/sign-up")
-    public ResponseEntity<BaseResponse> signUp(@RequestBody @Valid OwnerCreateRequest ownerCreateRequest) {
+    public ResponseEntity<BaseResponse> signUp(@RequestBody @Valid RiderCreateRequest riderCreateRequest) {
         return BaseResponse.toResponseEntity(
                 MemberResponse.CREATE_MEMBER_SUCCESS,
-                ownerMemberService.createOwner(ownerCreateRequest.toDto())
+                riderMemberService.createRider(riderCreateRequest.toDto())
         );
     }
 
@@ -37,7 +37,7 @@ public class OwnerMemberController {
         }
         return BaseResponse.toResponseEntity(
                 MemberResponse.GET_CURRENT_MEMBER_SUCCESS,
-                ownerMemberService.getCurrentOwner(userDetails.getUsername())
+                riderMemberService.getCurrentRider(userDetails.getUsername())
         );
     }
 }

--- a/src/main/java/com/idukbaduk/itseats/member/dto/RiderDto.java
+++ b/src/main/java/com/idukbaduk/itseats/member/dto/RiderDto.java
@@ -1,0 +1,48 @@
+package com.idukbaduk.itseats.member.dto;
+
+import com.idukbaduk.itseats.member.entity.Member;
+import com.idukbaduk.itseats.member.entity.enums.MemberType;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class RiderDto {
+
+    private String username;
+
+    private String password;
+
+    private String name;
+
+    private String nickname;
+
+    private String email;
+
+    private String phone;
+
+    @Builder
+    public RiderDto(String username, String password, String name, String nickname, String email, String phone) {
+        this.username = username;
+        this.password = password;
+        this.name = name;
+        this.nickname = nickname;
+        this.email = email;
+        this.phone = phone;
+    }
+
+    public Member toEntity(String encryptedPassword) {
+        return Member.builder()
+                .username(this.username)
+                .password(encryptedPassword)
+                .name(this.name)
+                .nickname(this.nickname)
+                .email(this.email)
+                .phone(this.phone)
+                .memberType(MemberType.RIDER)
+                .build();
+    }
+
+}

--- a/src/main/java/com/idukbaduk/itseats/member/dto/request/RiderCreateRequest.java
+++ b/src/main/java/com/idukbaduk/itseats/member/dto/request/RiderCreateRequest.java
@@ -1,0 +1,38 @@
+package com.idukbaduk.itseats.member.dto.request;
+
+import com.idukbaduk.itseats.member.dto.RiderDto;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
+public record RiderCreateRequest(
+        @NotBlank String username,
+
+        @NotBlank @Pattern(
+                regexp = "^(?=.*[a-zA-Z])(?=.*\\d)(?=.*[@$!%*?&])[A-Za-z\\d@$!%*?&]{8,}$",
+                message = "비밀번호는 최소 8자리, 영문, 숫자, 특수문자를 포함해야 합니다"
+        ) String password,
+
+        @NotBlank String name,
+
+        @NotBlank String nickname,
+
+        @Email String email,
+
+        @NotBlank @Pattern(
+                regexp = "^01[0-9]-\\d{4}-\\d{4}$", message = "올바른 휴대폰 번호 형식이 아닙니다"
+        ) String phone
+)
+{
+    public RiderDto toDto() {
+        return RiderDto.builder()
+                .username(this.username)
+                .password(this.password)
+                .name(this.name)
+                .nickname(this.nickname)
+                .email(this.email)
+                .phone(this.phone)
+                .build();
+    }
+
+}

--- a/src/main/java/com/idukbaduk/itseats/member/dto/response/CurrentRiderResponse.java
+++ b/src/main/java/com/idukbaduk/itseats/member/dto/response/CurrentRiderResponse.java
@@ -1,0 +1,40 @@
+package com.idukbaduk.itseats.member.dto.response;
+
+import com.idukbaduk.itseats.member.entity.Member;
+import com.idukbaduk.itseats.rider.entity.Rider;
+import com.idukbaduk.itseats.store.dto.PointDto;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class CurrentRiderResponse {
+    private Long memberId;
+    private String username;
+    private String name;
+    private String nickname;
+    private String email;
+    private String phone;
+    private String memberType;
+
+    private String deliveryMethod;
+    private Boolean isWorking;
+    private PointDto location;
+    private String preferredArea;
+
+    public static CurrentRiderResponse of(Member member, Rider rider) {
+        return CurrentRiderResponse.builder()
+                .memberId(member.getMemberId())
+                .username(member.getUsername())
+                .name(member.getName())
+                .nickname(member.getNickname())
+                .email(member.getEmail())
+                .phone(member.getPhone())
+                .memberType(member.getMemberType().name())
+                .deliveryMethod(rider.getDeliveryMethod().name())
+                .isWorking(rider.getIsWorking())
+                .location(new PointDto(rider.getLocation()))
+                .preferredArea(rider.getPreferredArea())
+                .build();
+    }
+}

--- a/src/main/java/com/idukbaduk/itseats/member/service/OwnerMemberService.java
+++ b/src/main/java/com/idukbaduk/itseats/member/service/OwnerMemberService.java
@@ -41,8 +41,8 @@ public class OwnerMemberService {
         }
 
         String encryptedPassword = passwordEncoder.encode(ownerDto.getPassword());
-        Member newCustomer = memberRepository.save(ownerDto.toEntity(encryptedPassword));
-        return MemberCreateResponse.of(newCustomer.getMemberId());
+        Member newOwner = memberRepository.save(ownerDto.toEntity(encryptedPassword));
+        return MemberCreateResponse.of(newOwner.getMemberId());
     }
 
     public CurrentOwnerResponse getCurrentOwner(String username) {

--- a/src/main/java/com/idukbaduk/itseats/member/service/RiderMemberService.java
+++ b/src/main/java/com/idukbaduk/itseats/member/service/RiderMemberService.java
@@ -1,0 +1,60 @@
+package com.idukbaduk.itseats.member.service;
+
+import com.idukbaduk.itseats.member.dto.RiderDto;
+import com.idukbaduk.itseats.member.dto.response.CurrentRiderResponse;
+import com.idukbaduk.itseats.member.dto.response.MemberCreateResponse;
+import com.idukbaduk.itseats.member.entity.Member;
+import com.idukbaduk.itseats.member.error.MemberException;
+import com.idukbaduk.itseats.member.error.enums.MemberErrorCode;
+import com.idukbaduk.itseats.member.repository.MemberRepository;
+import com.idukbaduk.itseats.rider.entity.Rider;
+import com.idukbaduk.itseats.rider.error.RiderException;
+import com.idukbaduk.itseats.rider.error.enums.RiderErrorCode;
+import com.idukbaduk.itseats.rider.repository.RiderRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class RiderMemberService {
+
+    private final PasswordEncoder passwordEncoder;
+    private final MemberRepository memberRepository;
+    private final RiderRepository riderRepository;
+
+    @Transactional
+    public MemberCreateResponse createRider(RiderDto riderDto) {
+
+        if (memberRepository.existsByUsername(riderDto.getUsername())) {
+            throw new MemberException(MemberErrorCode.MEMBER_USERNAME_DUPLICATED);
+        }
+
+        if (memberRepository.existsByNickname(riderDto.getNickname())) {
+            throw new MemberException(MemberErrorCode.MEMBER_NICKNAME_DUPLICATED);
+        }
+
+        if (memberRepository.existsByEmail(riderDto.getEmail())) {
+            throw new MemberException(MemberErrorCode.MEMBER_EMAIL_DUPLICATED);
+        }
+
+        String encryptedPassword = passwordEncoder.encode(riderDto.getPassword());
+        Member newRider = memberRepository.save(riderDto.toEntity(encryptedPassword));
+        return MemberCreateResponse.of(newRider.getMemberId());
+    }
+
+    public CurrentRiderResponse getCurrentRider(String username) {
+        Member member = memberRepository.findByUsername(username).orElseThrow(
+                () -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND)
+        );
+
+        Rider rider = riderRepository.findByMember(member).orElseThrow(
+                () -> new RiderException(RiderErrorCode.RIDER_NOT_FOUND)
+        );
+
+        return CurrentRiderResponse.of(member, rider);
+    }
+}

--- a/src/main/java/com/idukbaduk/itseats/rider/controller/RiderController.java
+++ b/src/main/java/com/idukbaduk/itseats/rider/controller/RiderController.java
@@ -44,7 +44,7 @@ public class RiderController {
     }
 
     @PostMapping("/location")
-    public ResponseEntity<BaseResponse> getNearbyOrders(
+    public ResponseEntity<BaseResponse> updateRiderLocation(
             @AuthenticationPrincipal UserDetails userDetails,
             @RequestBody LocationRequest request
     ) {

--- a/src/main/java/com/idukbaduk/itseats/rider/controller/RiderController.java
+++ b/src/main/java/com/idukbaduk/itseats/rider/controller/RiderController.java
@@ -2,8 +2,9 @@ package com.idukbaduk.itseats.rider.controller;
 
 import com.idukbaduk.itseats.global.response.BaseResponse;
 import com.idukbaduk.itseats.rider.dto.ModifyWorkingRequest;
-import com.idukbaduk.itseats.rider.dto.NearByOrderRequest;
+import com.idukbaduk.itseats.rider.dto.LocationRequest;
 import com.idukbaduk.itseats.rider.dto.RejectReasonRequest;
+import com.idukbaduk.itseats.rider.dto.RiderInfoRequest;
 import com.idukbaduk.itseats.rider.dto.enums.RiderResponse;
 import com.idukbaduk.itseats.rider.service.RiderService;
 import jakarta.validation.Valid;
@@ -23,6 +24,15 @@ public class RiderController {
 
     private final RiderService riderService;
 
+    @PostMapping("/regist")
+    public ResponseEntity<BaseResponse> createRider(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @RequestBody RiderInfoRequest request
+    ) {
+        riderService.createRider(userDetails.getUsername(), request);
+        return BaseResponse.toResponseEntity(RiderResponse.CREATE_RIDER_SUCCESS);
+    }
+
     @PostMapping("/working")
     public ResponseEntity<BaseResponse> modifyWorking(
             @AuthenticationPrincipal UserDetails userDetails,
@@ -31,6 +41,15 @@ public class RiderController {
                 RiderResponse.MODIFY_IS_WORKING_SUCCESS,
                 riderService.modifyWorking(userDetails.getUsername(), modifyWorkingRequest)
         );
+    }
+
+    @PostMapping("/location")
+    public ResponseEntity<BaseResponse> getNearbyOrders(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @RequestBody LocationRequest request
+    ) {
+        riderService.updateLocation(userDetails.getUsername(), request);
+        return BaseResponse.toResponseEntity(RiderResponse.UPDATE_LOCATION_SUCCESS);
     }
 
     @PutMapping("/{orderId}/reject")
@@ -57,7 +76,7 @@ public class RiderController {
             Double longitude
     ) {
 
-        NearByOrderRequest request = new NearByOrderRequest(latitude, longitude);
+        LocationRequest request = new LocationRequest(latitude, longitude);
 
         return BaseResponse.toResponseEntity(
                 RiderResponse.GET_NEARBY_ORDERS_SUCCESS,

--- a/src/main/java/com/idukbaduk/itseats/rider/dto/LocationRequest.java
+++ b/src/main/java/com/idukbaduk/itseats/rider/dto/LocationRequest.java
@@ -7,7 +7,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
-public class NearByOrderRequest {
+public class LocationRequest {
     private Double latitude;
     private Double longitude;
 }

--- a/src/main/java/com/idukbaduk/itseats/rider/dto/RiderInfoRequest.java
+++ b/src/main/java/com/idukbaduk/itseats/rider/dto/RiderInfoRequest.java
@@ -1,0 +1,24 @@
+package com.idukbaduk.itseats.rider.dto;
+
+import com.idukbaduk.itseats.member.entity.Member;
+import com.idukbaduk.itseats.rider.entity.Rider;
+import com.idukbaduk.itseats.rider.entity.enums.DeliveryMethod;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class RiderInfoRequest {
+
+    private DeliveryMethod deliveryMethod;
+    private String preferredArea;
+
+    public Rider toRider(Member member) {
+        return Rider.builder()
+                .member(member)
+                .deliveryMethod(deliveryMethod)
+                .isWorking(true)
+                .preferredArea(preferredArea)
+                .build();
+    }
+}

--- a/src/main/java/com/idukbaduk/itseats/rider/dto/enums/RiderResponse.java
+++ b/src/main/java/com/idukbaduk/itseats/rider/dto/enums/RiderResponse.java
@@ -7,7 +7,9 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum RiderResponse implements Response {
 
+    CREATE_RIDER_SUCCESS(HttpStatus.CREATED, "라이더 회원가입 성공"),
     MODIFY_IS_WORKING_SUCCESS(HttpStatus.OK, "출/퇴근 상태전환 성공"),
+    UPDATE_LOCATION_SUCCESS(HttpStatus.OK, "라이더 위치 갱신 성공"),
     UPDATE_STATUS_ACCEPT_SUCCESS(HttpStatus.OK, "배달 수락 완료"),
     UPDATE_STATUS_ARRIVED_SUCCESS(HttpStatus.OK, "매장 도착 완료"),
     UPDATE_STATUS_PICKUP_SUCCESS(HttpStatus.OK, "픽업 완료"),

--- a/src/main/java/com/idukbaduk/itseats/rider/entity/Rider.java
+++ b/src/main/java/com/idukbaduk/itseats/rider/entity/Rider.java
@@ -43,4 +43,8 @@ public class Rider extends BaseEntity {
     public void modifyIsWorking(Boolean isWorking) {
         this.isWorking = isWorking;
     }
+
+    public void updateLocation(Point location) {
+        this.location = location;
+    }
 }

--- a/src/main/java/com/idukbaduk/itseats/rider/entity/Rider.java
+++ b/src/main/java/com/idukbaduk/itseats/rider/entity/Rider.java
@@ -4,7 +4,6 @@ import com.idukbaduk.itseats.global.BaseEntity;
 import com.idukbaduk.itseats.member.entity.Member;
 import com.idukbaduk.itseats.rider.entity.enums.DeliveryMethod;
 import jakarta.persistence.*;
-import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;

--- a/src/main/java/com/idukbaduk/itseats/rider/error/enums/RiderErrorCode.java
+++ b/src/main/java/com/idukbaduk/itseats/rider/error/enums/RiderErrorCode.java
@@ -8,6 +8,7 @@ import org.springframework.http.HttpStatus;
 public enum RiderErrorCode implements ErrorCode {
 
     RIDER_NOT_FOUND(HttpStatus.NOT_FOUND, "라이더 조회 실패"),
+    RIDER_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "라이더로 이미 가입하였습니다."),
     RIDER_ASSIGNMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "라이더 주문 할당 정보 조회 실패"),
     RIDER_ASSIGNMENT_STATUS_UPDATE_FAIL(HttpStatus.CONFLICT, "라이더 배차 관리 상태 변경 실패"),
     RIDER_LOCATION_NOT_FOUND(HttpStatus.NOT_FOUND, "라이더 위치 정보가 없습니다."),

--- a/src/main/java/com/idukbaduk/itseats/rider/service/RiderService.java
+++ b/src/main/java/com/idukbaduk/itseats/rider/service/RiderService.java
@@ -1,5 +1,6 @@
 package com.idukbaduk.itseats.rider.service;
 
+import com.idukbaduk.itseats.global.util.GeoUtil;
 import com.idukbaduk.itseats.member.entity.Member;
 import com.idukbaduk.itseats.member.error.MemberException;
 import com.idukbaduk.itseats.member.error.enums.MemberErrorCode;
@@ -53,6 +54,18 @@ public class RiderService {
                 .build();
     }
 
+    @Transactional
+    public void updateLocation(String username, LocationRequest request) {
+        Member member = memberRepository.findByUsername(username).orElseThrow(
+                () -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND)
+        );
+
+        Rider rider = riderRepository.findByMember(member).orElseThrow(
+                () -> new RiderException(RiderErrorCode.RIDER_NOT_FOUND)
+        );
+        rider.updateLocation(GeoUtil.toPoint(request.getLongitude(), request.getLatitude()));
+    }
+
     public void createRiderAssignment(Rider rider, Order order) {
         riderAssignmentRepository.save(buildRiderAssignment(rider, order));
     }
@@ -89,7 +102,7 @@ public class RiderService {
     }
 
     @Transactional(readOnly = true)
-    public List<ReadyOrderResponse> findNearbyOrders(NearByOrderRequest request) {
+    public List<ReadyOrderResponse> findNearbyOrders(LocationRequest request) {
         final int searchRadiusMeters = DEFAULT_SEARCH_RADIUS_KM * 1000; // 10km
 
         List<NearbyOrderDTO> nearbyOrders = orderRepository.findNearbyOrders(

--- a/src/main/java/com/idukbaduk/itseats/rider/service/RiderService.java
+++ b/src/main/java/com/idukbaduk/itseats/rider/service/RiderService.java
@@ -39,6 +39,10 @@ public class RiderService {
                 () -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND)
         );
 
+        if (riderRepository.findByMember(member).isPresent()) {
+            throw new RiderException(RiderErrorCode.RIDER_ALREADY_EXISTS);
+        }
+
         riderRepository.save(request.toRider(member));
     }
 

--- a/src/main/java/com/idukbaduk/itseats/rider/service/RiderService.java
+++ b/src/main/java/com/idukbaduk/itseats/rider/service/RiderService.java
@@ -1,5 +1,9 @@
 package com.idukbaduk.itseats.rider.service;
 
+import com.idukbaduk.itseats.member.entity.Member;
+import com.idukbaduk.itseats.member.error.MemberException;
+import com.idukbaduk.itseats.member.error.enums.MemberErrorCode;
+import com.idukbaduk.itseats.member.repository.MemberRepository;
 import com.idukbaduk.itseats.order.dto.NearbyOrderDTO;
 import com.idukbaduk.itseats.order.entity.Order;
 import com.idukbaduk.itseats.order.repository.OrderRepository;
@@ -21,12 +25,21 @@ import java.util.List;
 @RequiredArgsConstructor
 public class RiderService {
 
+    private final MemberRepository memberRepository;
     private final RiderRepository riderRepository;
     private final RiderAssignmentRepository riderAssignmentRepository;
     private final OrderRepository orderRepository;
 
     private static final int DEFAULT_SEARCH_RADIUS_KM = 10;
 
+    @Transactional
+    public void createRider(String username, RiderInfoRequest request) {
+        Member member = memberRepository.findByUsername(username).orElseThrow(
+                () -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND)
+        );
+
+        riderRepository.save(request.toRider(member));
+    }
 
     @Transactional
     public WorkingInfoResponse modifyWorking(String username, ModifyWorkingRequest modifyWorkingRequest) {

--- a/src/test/java/com/idukbaduk/itseats/rider/service/FindNearbyOrdersServiceTest.java
+++ b/src/test/java/com/idukbaduk/itseats/rider/service/FindNearbyOrdersServiceTest.java
@@ -8,7 +8,7 @@ import com.idukbaduk.itseats.order.entity.Order;
 import com.idukbaduk.itseats.order.entity.enums.DeliveryType;
 import com.idukbaduk.itseats.order.entity.enums.OrderStatus;
 import com.idukbaduk.itseats.order.repository.OrderRepository;
-import com.idukbaduk.itseats.rider.dto.NearByOrderRequest;
+import com.idukbaduk.itseats.rider.dto.LocationRequest;
 import com.idukbaduk.itseats.rider.dto.ReadyOrderResponse;
 import com.idukbaduk.itseats.rider.error.RiderException;
 import com.idukbaduk.itseats.store.entity.Store;
@@ -155,7 +155,7 @@ class FindNearbyOrdersServiceTest {
         );
 
         // when
-        NearByOrderRequest request = new NearByOrderRequest(riderLat, riderLng);
+        LocationRequest request = new LocationRequest(riderLat, riderLng);
         List<ReadyOrderResponse> nearbyOrders = riderService.findNearbyOrders(request);
 
         // then
@@ -194,7 +194,7 @@ class FindNearbyOrdersServiceTest {
         );
 
         // when
-        NearByOrderRequest request = new NearByOrderRequest(riderLat, riderLng);
+        LocationRequest request = new LocationRequest(riderLat, riderLng);
 
         // then
         assertThatThrownBy(() -> riderService.findNearbyOrders(request))
@@ -231,7 +231,7 @@ class FindNearbyOrdersServiceTest {
         );
 
         //  when
-        NearByOrderRequest request = new NearByOrderRequest(riderLat, riderLng);
+        LocationRequest request = new LocationRequest(riderLat, riderLng);
         List<ReadyOrderResponse> nearbyOrders = riderService.findNearbyOrders(request);
 
         // then


### PR DESCRIPTION
## #️⃣연관된 이슈

#247 
closes #247

## 📝작업 내용

회원가입과 내 정보 조회 엔드포인트를 라이더 전용으로 분리합니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 라이더 회원가입 및 정보 조회를 위한 REST API가 추가되었습니다.
  * 라이더 회원가입 시 입력값 검증 및 중복 확인 기능이 적용되었습니다.
  * 라이더의 현재 정보(개인 및 배달 관련 정보)를 조회할 수 있는 기능이 제공됩니다.
  * 라이더 위치 등록 및 갱신 기능이 추가되었습니다.
  * 라이더 주변 주문 조회 기능이 위치 기반 요청으로 개선되었습니다.

* **버그 수정**
  * 인증되지 않은 사용자 접근 시 보다 명확한 오류 메시지로 처리됩니다.

* **기타**
  * 내부 변수명 및 예외 처리 방식이 개선되었습니다.
  * 위치 관련 요청 DTO 명칭이 변경되었습니다.
  * 라이더 회원가입 및 위치 갱신 성공 메시지가 추가되었습니다.
  * 라이더 중복 가입에 대한 오류 코드가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->