### PR TITLE
[Fix] 라이더 내 정보 조회시 Location null 예외 처리

### DIFF
--- a/src/main/java/com/idukbaduk/itseats/member/dto/response/CurrentRiderResponse.java
+++ b/src/main/java/com/idukbaduk/itseats/member/dto/response/CurrentRiderResponse.java
@@ -33,7 +33,7 @@ public class CurrentRiderResponse {
                 .memberType(member.getMemberType().name())
                 .deliveryMethod(rider.getDeliveryMethod().name())
                 .isWorking(rider.getIsWorking())
-                .location(new PointDto(rider.getLocation()))
+                .location(rider.getLocation() == null ? null : new PointDto(rider.getLocation()))
                 .preferredArea(rider.getPreferredArea())
                 .build();
     }


### PR DESCRIPTION
## #️⃣연관된 이슈

생략

## 📝작업 내용

라이더 내 정보 조회시 위치 `location`이 null일 경우 응답을 예외처리 합니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

간단한 내용이라 이슈는 생략합니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 라이더 위치 정보가 없을 때 발생할 수 있는 오류를 방지하여, 위치 정보가 없는 경우에도 안전하게 처리되도록 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->