### PR TITLE
[Fix] 동일 주문의 라이더 배차가 여러 개 생성되는 문제 수정

### DIFF
--- a/src/main/java/com/idukbaduk/itseats/order/controller/RiderOrderController.java
+++ b/src/main/java/com/idukbaduk/itseats/order/controller/RiderOrderController.java
@@ -76,6 +76,7 @@ public class RiderOrderController {
             @AuthenticationPrincipal UserDetails userDetails,
             @PathVariable("orderId") Long orderId) {
         riderOrderService.updateOrderStatus(userDetails.getUsername(), orderId, OrderStatus.DELIVERED);
+        riderOrderService.updateOrderStatus(userDetails.getUsername(), orderId, OrderStatus.COMPLETED);
         return BaseResponse.toResponseEntity(RiderResponse.UPDATE_STATUS_DELIVERED_SUCCESS);
     }
 

--- a/src/main/java/com/idukbaduk/itseats/rider/repository/RiderAssignmentRepository.java
+++ b/src/main/java/com/idukbaduk/itseats/rider/repository/RiderAssignmentRepository.java
@@ -25,4 +25,6 @@ public interface RiderAssignmentRepository extends JpaRepository<RiderAssignment
     );
 
     Optional<RiderAssignment> findByRiderAndOrder(Rider rider, Order order);
+
+    Boolean existsByRiderAndOrder(Rider rider, Order order);
 }

--- a/src/main/java/com/idukbaduk/itseats/rider/service/RiderService.java
+++ b/src/main/java/com/idukbaduk/itseats/rider/service/RiderService.java
@@ -17,11 +17,13 @@ import com.idukbaduk.itseats.rider.error.enums.RiderErrorCode;
 import com.idukbaduk.itseats.rider.repository.RiderAssignmentRepository;
 import com.idukbaduk.itseats.rider.repository.RiderRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class RiderService {
@@ -69,8 +71,10 @@ public class RiderService {
         rider.updateLocation(GeoUtil.toPoint(request.getLongitude(), request.getLatitude()));
     }
 
+    @Transactional
     public void createRiderAssignment(Rider rider, Order order) {
-        riderAssignmentRepository.save(buildRiderAssignment(rider, order));
+        if (!riderAssignmentRepository.existsByRiderAndOrder(rider, order))
+            riderAssignmentRepository.save(buildRiderAssignment(rider, order));
     }
 
     private RiderAssignment buildRiderAssignment(Rider rider, Order order) {


### PR DESCRIPTION
## #️⃣연관된 이슈

#278
closes #278

## 📝작업 내용

동일 주문의 라이더 배차가 여러 개 생성되는 문제 수정

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 라이더가 주문에 중복 할당되는 문제를 방지하여, 이미 할당된 경우에는 더 이상 할당되지 않도록 개선되었습니다.

* **기타 변경**
  * 주문 상태가 '배달 완료'에서 '완료'로 연속적으로 업데이트되도록 수정되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->